### PR TITLE
Add Nix flake and fish shell completions

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 node_modules/
+result

--- a/completions/pty.fish
+++ b/completions/pty.fish
@@ -1,0 +1,73 @@
+# Fish completion for pty
+# Persistent terminal sessions with detach/attach support
+
+function __pty_sessions
+    set -l session_dir "$PTY_SESSION_DIR"
+    if test -z "$session_dir"
+        set session_dir "$HOME/.local/state/pty"
+    end
+    if test -d "$session_dir"
+        for f in $session_dir/*.json
+            if test -f "$f"
+                basename $f .json
+            end
+        end
+    end
+end
+
+function __pty_needs_command
+    set -l cmd (commandline -opc)
+    test (count $cmd) -eq 1
+end
+
+function __pty_using_command
+    set -l cmd (commandline -opc)
+    test (count $cmd) -ge 2; and test "$cmd[2]" = "$argv[1]"
+end
+
+# Disable file completions by default
+complete -c pty -f
+
+# Subcommands
+complete -c pty -n __pty_needs_command -a run -d 'Create a session and attach'
+complete -c pty -n __pty_needs_command -a attach -d 'Attach to an existing session'
+complete -c pty -n __pty_needs_command -a peek -d 'Print current screen or follow output'
+complete -c pty -n __pty_needs_command -a send -d 'Send text or keys to a session'
+complete -c pty -n __pty_needs_command -a kill -d 'Kill or remove a session'
+complete -c pty -n __pty_needs_command -a list -d 'List active sessions'
+complete -c pty -n __pty_needs_command -a restart -d 'Restart a session'
+complete -c pty -n __pty_needs_command -a test -d 'Run tests'
+complete -c pty -n __pty_needs_command -a help -d 'Show usage information'
+
+# run: flags and file completion for the command argument
+complete -c pty -n '__pty_using_command run' -s d -l detach -d 'Create in background'
+complete -c pty -n '__pty_using_command run' -s a -l attach -d 'Attach if already running'
+complete -c pty -n '__pty_using_command run' -F
+
+# attach: session names and flags
+complete -c pty -n '__pty_using_command attach' -a '(__pty_sessions)' -d 'Session'
+complete -c pty -n '__pty_using_command attach' -s r -l auto-restart -d 'Auto-restart if exited'
+
+# peek: session names and flags
+complete -c pty -n '__pty_using_command peek' -a '(__pty_sessions)' -d 'Session'
+complete -c pty -n '__pty_using_command peek' -s f -l follow -d 'Follow output read-only'
+complete -c pty -n '__pty_using_command peek' -l plain -d 'Output plain text without ANSI'
+
+# send: session names and flags
+complete -c pty -n '__pty_using_command send' -a '(__pty_sessions)' -d 'Session'
+complete -c pty -n '__pty_using_command send' -l seq -d 'Send a sequence item' -r
+complete -c pty -n '__pty_using_command send' -l with-delay -d 'Delay between --seq items (seconds)' -r
+
+# kill: session names
+complete -c pty -n '__pty_using_command kill' -a '(__pty_sessions)' -d 'Session'
+
+# restart: session names and flags
+complete -c pty -n '__pty_using_command restart' -a '(__pty_sessions)' -d 'Session'
+complete -c pty -n '__pty_using_command restart' -s y -l yes -d 'Skip confirmation'
+
+# list: flags
+complete -c pty -n '__pty_using_command list' -l json -d 'Output as JSON'
+
+# test: subcommands and flags
+complete -c pty -n '__pty_using_command test' -a watch -d 'Watch mode'
+complete -c pty -n '__pty_using_command test' -s t -d 'Run matching tests' -r

--- a/flake.lock
+++ b/flake.lock
@@ -1,0 +1,61 @@
+{
+  "nodes": {
+    "flake-utils": {
+      "inputs": {
+        "systems": "systems"
+      },
+      "locked": {
+        "lastModified": 1731533236,
+        "narHash": "sha256-l0KFg5HjrsfsO/JpG+r7fRrqm12kzFHyUHqHCVpMMbI=",
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "rev": "11707dc2f618dd54ca8739b309ec4fc024de578b",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "type": "github"
+      }
+    },
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1773821835,
+        "narHash": "sha256-TJ3lSQtW0E2JrznGVm8hOQGVpXjJyXY2guAxku2O9A4=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "b40629efe5d6ec48dd1efba650c797ddbd39ace0",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixos-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "root": {
+      "inputs": {
+        "flake-utils": "flake-utils",
+        "nixpkgs": "nixpkgs"
+      }
+    },
+    "systems": {
+      "locked": {
+        "lastModified": 1681028828,
+        "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
+        "owner": "nix-systems",
+        "repo": "default",
+        "rev": "da67096a3b9bf56a91d16901293e51ba5b49a27e",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-systems",
+        "repo": "default",
+        "type": "github"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,63 @@
+{
+  inputs = {
+    nixpkgs.url = "github:NixOS/nixpkgs/nixos-unstable";
+    flake-utils.url = "github:numtide/flake-utils";
+  };
+
+  outputs =
+    {
+      self,
+      nixpkgs,
+      flake-utils,
+    }:
+    flake-utils.lib.eachDefaultSystem (
+      system:
+      let
+        pkgs = import nixpkgs { inherit system; };
+        pty = pkgs.buildNpmPackage {
+          pname = "pty";
+          version = "0.1.0";
+          src = self;
+
+          npmDepsHash = "sha256-xCWanXIKz2oqsii5kEK4RWhVROOkTPqitB2zRwbJObs=";
+
+          # The CLI runs TypeScript via tsx at runtime — no build step needed
+          dontBuild = true;
+
+          installPhase = ''
+            runHook preInstall
+
+            mkdir -p $out/lib/pty
+            cp -r . $out/lib/pty
+
+            mkdir -p $out/bin
+            ln -s $out/lib/pty/bin/pty $out/bin/pty
+            chmod +x $out/bin/pty
+
+            substituteInPlace $out/bin/pty \
+              --replace-fail "#!/usr/bin/env node" "#!${pkgs.nodejs}/bin/node"
+
+            # Shell completions
+            install -Dm644 completions/pty.bash $out/share/bash-completion/completions/pty
+            install -Dm644 completions/pty.zsh $out/share/zsh/site-functions/_pty
+            install -Dm644 completions/pty.fish $out/share/fish/vendor_completions.d/pty.fish
+
+            runHook postInstall
+          '';
+
+          meta = with pkgs.lib; {
+            description = "Persistent terminal sessions with detach/attach support";
+            homepage = "https://github.com/myobie/pty";
+            license = licenses.mit;
+            mainProgram = "pty";
+          };
+        };
+      in
+      {
+        packages = {
+          default = pty;
+          inherit pty;
+        };
+      }
+    );
+}


### PR DESCRIPTION
## Summary

- Add `flake.nix` with `buildNpmPackage` derivation for the `pty` CLI
- Add fish shell completions (`completions/pty.fish`) covering all subcommands and flags
- Install bash, zsh, and fish completions to standard Nix paths (`share/bash-completion/`, `share/zsh/site-functions/`, `share/fish/vendor_completions.d/`)
- Add `result` to `.gitignore` for nix build output

## Rationale

This makes `pty` installable via Nix flakes, which enables reproducible builds and easy consumption as a flake input in other projects:

```nix
# As a flake input
inputs.pty.url = "github:myobie/pty";

# Direct usage
nix run github:myobie/pty -- --help
nix shell github:myobie/pty
```

The derivation uses `buildNpmPackage` (nixpkgs) which handles the `node-pty` native prebuilds correctly and patches the shebang to use a Nix-provided Node.js.

## Test plan

- [x] `nix build .#pty` succeeds
- [x] `pty --help` works from the built output
- [x] `pty run -d test sleep 5 && pty list && pty kill test` — full session lifecycle works
- [x] Bash completions produce correct subcommands
- [x] Zsh completions installed at correct path
- [x] Fish completions produce correct subcommands and flags

---
> [!NOTE]
> This PR was created on behalf of @schickling

🤖 Generated with [Claude Code](https://claude.com/claude-code)