### PR TITLE
fix: make postinstall spawn-helper chmod work under pnpm GVS

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,6 +22,7 @@
     "dist/",
     "completions/",
     "docs/",
+    "scripts/postinstall.js",
     "README.md",
     "LICENSE"
   ],
@@ -45,7 +46,7 @@
   "scripts": {
     "build": "tsc -p tsconfig.build.json",
     "prepublishOnly": "npm run build",
-    "postinstall": "chmod +x node_modules/node-pty/prebuilds/*/spawn-helper 2>/dev/null || true",
+    "postinstall": "node scripts/postinstall.js",
     "prepare": "git config core.hooksPath githooks 2>/dev/null || true; sh scripts/update-nix-hash.sh 2>/dev/null || true",
     "install-completions": "sh scripts/install-completions.sh",
     "typecheck": "tsc",

--- a/scripts/postinstall.js
+++ b/scripts/postinstall.js
@@ -1,0 +1,46 @@
+// Ensure node-pty's prebuilt `spawn-helper` is executable. Necessary because
+// node-pty's published tarball ships the file with mode 0644 and its own
+// post-install never chmods it. The previous workaround used a relative path
+// (`node_modules/node-pty/prebuilds/*/spawn-helper`) which silently no-ops
+// under pnpm with `enableGlobalVirtualStore`, where node-pty lives in a
+// sibling content-addressed link rather than nested under @myobie/pty.
+//
+// The root-cause fix belongs in microsoft/node-pty; once that ships, this
+// script can be removed entirely.
+
+import * as fs from "node:fs";
+import * as path from "node:path";
+import { createRequire } from "node:module";
+import { pathToFileURL } from "node:url";
+
+if (process.platform === "win32") process.exit(0);
+
+// Resolve from this package's root (package.json sibling), not from the
+// script file, so that node-pty is discoverable regardless of whether
+// node_modules is nested (npm/yarn/bun) or a sibling link (pnpm GVS).
+const pkgDir = path.dirname(new URL(import.meta.url).pathname);
+const requireFromPkg = createRequire(
+  pathToFileURL(path.join(pkgDir, "..", "package.json")),
+);
+
+let nodePtyDir;
+try {
+  nodePtyDir = path.dirname(requireFromPkg.resolve("node-pty/package.json"));
+} catch {
+  console.warn("[@myobie/pty] node-pty not found; skipping spawn-helper chmod");
+  process.exit(0);
+}
+
+const helper = path.join(
+  nodePtyDir,
+  "prebuilds",
+  `${process.platform}-${process.arch}`,
+  "spawn-helper",
+);
+
+try {
+  fs.chmodSync(helper, 0o755);
+} catch {
+  // Acceptable when there's no prebuild for this arch and node-pty was
+  // built from source — node-gyp produces the binary executable already.
+}


### PR DESCRIPTION
## Summary

The current `postinstall` workaround silently no-ops under pnpm with `enableGlobalVirtualStore`, leaving `node-pty`'s `spawn-helper` non-executable and causing `posix_spawnp failed` at runtime.

## Repro

```sh
mkdir scratch && cd scratch
pnpm init
pnpm add @myobie/pty
ls -l node_modules/.pnpm/node-pty@*/node_modules/node-pty/prebuilds/darwin-arm64/spawn-helper
# -rw-r--r--  ← should be 755
node -e "import('@myobie/pty/testing').then(m => m.Session.spawn('echo', ['hi']))"
# Error: posix_spawnp failed.
```

## Root cause

The existing `postinstall`:

```json
"postinstall": "chmod +x node_modules/node-pty/prebuilds/*/spawn-helper 2>/dev/null || true"
```

uses a relative path that only resolves in flat `node_modules` layouts. Under pnpm's content-addressed store (especially with `enableGlobalVirtualStore`), `@myobie/pty`'s lifecycle CWD is `~/Library/pnpm/store/v11/links/@myobie/pty/0.4.1/<hash>/node_modules/@myobie/pty/`, and `node-pty` lives in a sibling content-addressed link — not nested. The relative `node_modules/node-pty/...` path doesn't exist there. The chmod fails, `2>/dev/null || true` swallows the error, and the user is left with a non-executable binary.

The root cause is in `node-pty` itself (its published tarball ships `spawn-helper` with mode 0644 and its own post-install never chmods it). The fix is already merged upstream in microsoft/node-pty#858 and #866, but `node-pty@1.1.0` (the latest published) predates those merges. So this `@myobie/pty` workaround needs to actually work until a newer node-pty ships.

## The fix

Replace the broken shell `chmod` with `scripts/postinstall.js`:

- Uses `createRequire(import.meta.url)` anchored at this package's own location, then `require.resolve('node-pty/package.json')` to find `node-pty` regardless of layout.
- `chmod 0755` the platform-specific `spawn-helper` (Linux + macOS).
- No-op on Windows.
- Silently skips when there's no prebuild for the current arch (acceptable: source builds via `node-gyp` produce executable binaries directly).
- ESM (matches `"type": "module"` in `package.json`).

Also added `scripts/` to the published `files` array — without this, the script doesn't end up in the tarball.

## Validation

End-to-end tested locally:

1. `npm pack` to produce a tarball
2. Installed into a fresh pnpm scratch project with `enableGlobalVirtualStore: true`
3. Verified `find ~/Library/pnpm -name spawn-helper | xargs ls -l` shows `0755`
4. Verified `Session.spawn('echo', ['hi'])` works without `posix_spawnp failed`
5. Confirmed the old shell workaround silently no-ops in the same layout (`chmod` exits 1, swallowed by `|| true`)

## Future

Once a new `node-pty` release ships with the upstream chmod fix (microsoft/node-pty#858, #866), this `scripts/postinstall.js` can be deleted entirely — `@myobie/pty` won't need its own workaround anymore.

## Context

I'm building [`@overeng/pty-effect`](https://github.com/overengineeringstudio/effect-utils), an Effect-native wrapper around `@myobie/pty`, and discovered this while validating against my test suite. Related upstream conversations:

- myobie/pty#6 — `./client` subpath exports
- myobie/pty#7 — `EventFollower` shipping

---
*Filed on behalf of @schickling.*