### PR TITLE
fix: handle invalid cwd errors explicitly

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -17,8 +17,12 @@ import {
   type SessionInfo,
 } from "./sessions.ts";
 import { spawnDaemon, resolveCommand } from "./spawn.ts";
-import { runInteractive } from "./tui/interactive.ts";
 import { EventFollower, readRecentEvents, formatEvent } from "./events.ts";
+
+const runInteractive = async (): Promise<void> => {
+  const { runInteractive } = await import("./tui/interactive.ts");
+  await runInteractive();
+};
 
 function usage(): void {
   console.log(`Usage:

--- a/src/server.ts
+++ b/src/server.ts
@@ -74,6 +74,32 @@ function queryProcessResources(pid: number): ProcessResources | null {
   }
 }
 
+function describeInvalidCwd(cwd: string): string | undefined {
+  if (cwd.length === 0) return "Working directory is empty.";
+
+  let stats: fs.Stats;
+  try {
+    stats = fs.statSync(cwd);
+  } catch (err: any) {
+    if (err?.code === "ENOENT") {
+      return `Working directory does not exist: ${cwd}`;
+    }
+    return `Working directory is not accessible: ${cwd} (${err?.message ?? String(err)})`;
+  }
+
+  if (!stats.isDirectory()) {
+    return `Working directory is not a directory: ${cwd}`;
+  }
+
+  try {
+    fs.accessSync(cwd, fs.constants.X_OK);
+  } catch {
+    return `Working directory is not searchable: ${cwd}`;
+  }
+
+  return undefined;
+}
+
 export class PtyServer {
   private terminal: Terminal;
   private serialize: SerializeAddon;
@@ -220,6 +246,14 @@ export class PtyServer {
     const childEnv = { ...process.env };
     delete childEnv.PTY_SERVER_CONFIG;
     childEnv.PTY_SESSION = options.name;
+
+    const invalidCwd = describeInvalidCwd(options.cwd);
+    if (invalidCwd !== undefined) {
+      throw new Error(
+        `${invalidCwd}\nCannot start session "${options.name}" for command "${options.command}".`
+      );
+    }
+
     try {
       this.ptyProcess = pty.spawn(
         "/bin/sh",
@@ -236,7 +270,7 @@ export class PtyServer {
       const msg = err?.message ?? String(err);
       if (msg.includes("posix_spawnp") || msg.includes("spawn")) {
         throw new Error(
-          `Failed to spawn "${options.command}": ${msg}\nIs the command installed and executable?`
+          `Failed to spawn PTY shell "/bin/sh" for command "${options.command}" in cwd "${options.cwd}": ${msg}`
         );
       }
       throw err;

--- a/tests/spawn-options.test.ts
+++ b/tests/spawn-options.test.ts
@@ -82,6 +82,46 @@ async function startDaemonWithSize(
   throw new Error(`Timeout waiting for daemon socket: ${socketPath}`);
 }
 
+async function startDaemonExpectFailure(
+  sessionDir: string,
+  name: string,
+  cwd: string,
+  command = "cat",
+  args: string[] = [],
+): Promise<{ exitCode: number | null; stderr: string }> {
+  const config = JSON.stringify({
+    name,
+    command,
+    args,
+    displayCommand: command,
+    cwd,
+    rows: 24,
+    cols: 80,
+  });
+
+  const child = spawn(nodeBin, [serverModule], {
+    stdio: ["ignore", "ignore", "pipe"],
+    env: {
+      ...process.env,
+      PTY_SERVER_CONFIG: config,
+      PTY_SESSION_DIR: sessionDir,
+    },
+  });
+
+  let stderr = "";
+  child.stderr?.on("data", (d: Buffer) => { stderr += d.toString(); });
+
+  const exitCode = await new Promise<number | null>((resolve, reject) => {
+    const timer = setTimeout(() => reject(new Error("Timed out waiting for daemon failure")), 5000);
+    child.on("exit", (code) => {
+      clearTimeout(timer);
+      resolve(code);
+    });
+  });
+
+  return { exitCode, stderr };
+}
+
 afterEach(() => {
   for (const pid of bgPids) {
     try { process.kill(pid, "SIGTERM"); } catch {}
@@ -148,5 +188,45 @@ describe("spawnDaemon options", () => {
     const stats = await queryStats(name);
     expect(stats.terminal.rows).toBe(24);
     expect(stats.terminal.cols).toBe(80);
+  }, 15000);
+
+  it("surfaces a missing cwd explicitly instead of failing silently", async () => {
+    const dir = makeSessionDir();
+    const name = uniqueName();
+    const missingDir = path.join(testRoot, `missing-${name}`);
+
+    const result = await startDaemonExpectFailure(dir, name, missingDir);
+
+    expect(result.exitCode).toBe(1);
+    expect(result.stderr).toContain(`Working directory does not exist: ${missingDir}`);
+    expect(result.stderr).toContain(`Cannot start session "${name}"`);
+  }, 15000);
+
+  it("surfaces a non-directory cwd explicitly instead of reporting posix_spawnp", async () => {
+    const dir = makeSessionDir();
+    const name = uniqueName();
+    const filePath = path.join(testRoot, `file-${name}`);
+    fs.writeFileSync(filePath, "not a directory");
+
+    const result = await startDaemonExpectFailure(dir, name, filePath);
+
+    expect(result.exitCode).toBe(1);
+    expect(result.stderr).toContain(`Working directory is not a directory: ${filePath}`);
+    expect(result.stderr).not.toContain("posix_spawnp failed");
+  }, 15000);
+
+  it("non-interactive CLI commands still work when the caller cwd was deleted", () => {
+    const dir = makeSessionDir();
+    const deletedCwd = fs.mkdtempSync(path.join(testRoot, "deleted-cwd-"));
+    const script = `cd ${JSON.stringify(deletedCwd)} && rmdir ${JSON.stringify(deletedCwd)} && exec ${JSON.stringify(nodeBin)} ${JSON.stringify(cliPath)} list`;
+
+    const result = spawnSync("sh", ["-lc", script], {
+      env: { ...process.env, PTY_SESSION_DIR: dir },
+      encoding: "utf-8",
+      timeout: 10000,
+    });
+
+    expect(result.status).toBe(0);
+    expect(result.stderr).not.toContain("uv_cwd");
   }, 15000);
 });


### PR DESCRIPTION
Closes #9.

## Summary

This fixes two related cwd-handling problems in PTY:

- validate `cwd` before `pty.spawn(...)` and surface explicit errors for missing / non-directory / non-searchable paths
- lazy-load the interactive UI so non-interactive CLI commands do not crash just because the caller's cwd was deleted

## Why

`pty run -a` and `pty restart` intentionally preserve the previous session cwd. When that worktree disappears, the current code either:

- exits with code `1` and no useful explanation, or
- rewrites `posix_spawnp failed` into a misleading "is the command installed?" error

Separately, `src/cli.ts` imported `./tui/interactive.ts` at module scope, so a deleted caller cwd could crash even `pty list` before argument handling.

## Verification

- `./node_modules/.bin/tsc -p tsconfig.build.json`
- `CI=1 ./node_modules/.bin/vitest run tests/spawn-options.test.ts`

The added tests verify:

- missing cwd is reported explicitly
- non-directory cwd is reported explicitly instead of `posix_spawnp failed`
- non-interactive CLI commands still run when the caller cwd was deleted

## Notes

I also ran the repo's broader `npm test` suite in this environment. It already fails widely on upstream `main`, so I used the focused build + regression suite above to verify this change without attributing unrelated baseline failures to this patch.

Acting on behalf of the user.
