### PR TITLE
feat: add browser-safe /protocol subpath export

### DIFF
--- a/package.json
+++ b/package.json
@@ -41,6 +41,10 @@
     "./client": {
       "types": "./dist/client-api.d.ts",
       "default": "./dist/client-api.js"
+    },
+    "./protocol": {
+      "types": "./dist/protocol.d.ts",
+      "default": "./dist/protocol.js"
     }
   },
   "scripts": {


### PR DESCRIPTION
## Summary

- Adds `./protocol` to the `package.json` exports map, pointing at the existing `src/protocol.ts` module
- The protocol module only depends on `node:buffer` (no `node:fs`, `node:net`, `node:child_process`, `node:events`) — fully browser-safe
- Committed `dist/protocol.js` + `dist/protocol.d.ts` for pnpm git-dep consumers (same pattern as existing fork branches)

## Why

Consumers like [forge](https://github.com/schickling/dotfiles) need the wire protocol types (`PacketReader`, `MessageType`, encode/decode helpers) in browser bundles. Currently the only way to reach the protocol is through `@myobie/pty/client`, which pulls in Node-only dependencies (`node:net`, `node:events`, `node:child_process` via node-pty). A dedicated `/protocol` subpath lets browser consumers import just the wire format without any Node baggage.

## What changed

- **`package.json`**: Added `"./protocol"` export entry (types + default) after the existing `./client` entry
- **`dist/protocol.js` + `dist/protocol.d.ts`**: Build artifacts committed for git-dep consumers

No changes to `src/protocol.ts` itself.

---

*This PR was authored by @schickling with assistance from Claude.*