### PR TITLE
fix: encode shift+non-letter keys using CSI u sequences

### DIFF
--- a/src/keys.ts
+++ b/src/keys.ts
@@ -19,6 +19,27 @@ const KEY_MAP: Record<string, string> = {
 
 const MODIFIERS = new Set(["ctrl", "alt", "shift"]);
 
+/** Keycodes for CSI u encoding (Kitty keyboard protocol). */
+const CSI_U_KEYCODES: Record<string, number> = {
+  return: 13,
+  enter: 13,
+  tab: 9,
+  escape: 27,
+  esc: 27,
+  space: 32,
+  backspace: 127,
+};
+
+/** Compute xterm modifier parameter: 1 + bitmask(shift=1, alt=2, ctrl=4). */
+function modifierParam(mods: Set<string>): number {
+  return (
+    1 +
+    (mods.has("shift") ? 1 : 0) +
+    (mods.has("alt") ? 2 : 0) +
+    (mods.has("ctrl") ? 4 : 0)
+  );
+}
+
 /** Parse a key spec like `ctrl+c`, `return`, `alt+x` into bytes. */
 export function resolveKey(spec: string): string {
   const parts = spec.toLowerCase().split("+");
@@ -32,40 +53,64 @@ export function resolveKey(spec: string): string {
     }
   }
 
-  let result: string;
+  const isLetter = base.length === 1 && base >= "a" && base <= "z";
+  const hasModifiers = mods.size > 0;
+  const mapped = KEY_MAP[base];
 
-  if (KEY_MAP[base] !== undefined) {
-    result = KEY_MAP[base];
-  } else if (base.length === 1 && base >= "a" && base <= "z") {
-    result = base;
-  } else {
+  if (mapped === undefined && !isLetter) {
     throw new Error(`Unknown key: "${base}" in key spec "${spec}"`);
   }
 
-  // Apply shift (only meaningful for single letters)
-  if (mods.has("shift")) {
-    if (result.length === 1 && result >= "a" && result <= "z") {
+  // Single letter keys
+  if (isLetter) {
+    let result = base;
+
+    if (mods.has("shift")) {
       result = result.toUpperCase();
     }
-    // shift on non-letters is silently ignored (e.g. shift+return = return)
-  }
 
-  // Apply ctrl (only meaningful for single letters)
-  if (mods.has("ctrl")) {
-    if (result.length === 1) {
+    if (mods.has("ctrl")) {
       const code = result.toLowerCase().charCodeAt(0);
-      if (code >= 97 && code <= 122) {
-        result = String.fromCharCode(code - 96);
-      }
+      result = String.fromCharCode(code - 96);
     }
+
+    if (mods.has("alt")) {
+      result = "\x1b" + result;
+    }
+
+    return result;
   }
 
-  // Apply alt (prefix with ESC)
-  if (mods.has("alt")) {
-    result = "\x1b" + result;
+  // Named keys without modifiers: return the mapped value directly
+  if (!hasModifiers) {
+    return mapped;
   }
 
-  return result;
+  const mod = modifierParam(mods);
+
+  // Special case: shift+tab produces legacy backtab sequence
+  if (base === "tab" && mod === 2) {
+    return "\x1b[Z";
+  }
+
+  // CSI sequences: \x1b[N~ (e.g. delete, pageup) or \x1b[X (e.g. arrows, home, end)
+  const csiTilde = mapped.match(/^\x1b\[(\d+)~$/);
+  if (csiTilde) {
+    return `\x1b[${csiTilde[1]};${mod}~`;
+  }
+
+  const csiLetter = mapped.match(/^\x1b\[([A-Z])$/);
+  if (csiLetter) {
+    return `\x1b[1;${mod}${csiLetter[1]}`;
+  }
+
+  // Control char keys (return, tab, escape, space, backspace): use CSI u encoding
+  const keycode = CSI_U_KEYCODES[base];
+  if (keycode !== undefined) {
+    return `\x1b[${keycode};${mod}u`;
+  }
+
+  return mapped;
 }
 
 /** If value starts with `key:`, resolve the key name; otherwise return the literal string. */

--- a/tests/keys.test.ts
+++ b/tests/keys.test.ts
@@ -39,9 +39,59 @@ describe("resolveKey", () => {
     expect(resolveKey("alt+a")).toBe("\x1ba");
   });
 
-  it("resolves shift chords", () => {
+  it("resolves shift chords for letters", () => {
     expect(resolveKey("shift+a")).toBe("A");
     expect(resolveKey("shift+z")).toBe("Z");
+  });
+
+  it("resolves shift+return via CSI u encoding", () => {
+    expect(resolveKey("shift+return")).toBe("\x1b[13;2u");
+    expect(resolveKey("shift+enter")).toBe("\x1b[13;2u");
+  });
+
+  it("resolves shift+tab as legacy backtab", () => {
+    expect(resolveKey("shift+tab")).toBe("\x1b[Z");
+  });
+
+  it("resolves shift+escape and shift+space via CSI u", () => {
+    expect(resolveKey("shift+escape")).toBe("\x1b[27;2u");
+    expect(resolveKey("shift+space")).toBe("\x1b[32;2u");
+    expect(resolveKey("shift+backspace")).toBe("\x1b[127;2u");
+  });
+
+  it("resolves shift+arrow keys with modifier parameter", () => {
+    expect(resolveKey("shift+up")).toBe("\x1b[1;2A");
+    expect(resolveKey("shift+down")).toBe("\x1b[1;2B");
+    expect(resolveKey("shift+right")).toBe("\x1b[1;2C");
+    expect(resolveKey("shift+left")).toBe("\x1b[1;2D");
+  });
+
+  it("resolves shift+navigation keys with modifier parameter", () => {
+    expect(resolveKey("shift+home")).toBe("\x1b[1;2H");
+    expect(resolveKey("shift+end")).toBe("\x1b[1;2F");
+    expect(resolveKey("shift+pageup")).toBe("\x1b[5;2~");
+    expect(resolveKey("shift+pagedown")).toBe("\x1b[6;2~");
+    expect(resolveKey("shift+delete")).toBe("\x1b[3;2~");
+  });
+
+  it("resolves ctrl+shift combinations", () => {
+    expect(resolveKey("ctrl+shift+up")).toBe("\x1b[1;6A");
+    expect(resolveKey("ctrl+shift+return")).toBe("\x1b[13;6u");
+  });
+
+  it("resolves alt+shift combinations", () => {
+    expect(resolveKey("alt+shift+up")).toBe("\x1b[1;4A");
+    expect(resolveKey("alt+shift+return")).toBe("\x1b[13;4u");
+  });
+
+  it("resolves ctrl+alt on named keys", () => {
+    expect(resolveKey("ctrl+alt+up")).toBe("\x1b[1;7A");
+    expect(resolveKey("ctrl+alt+delete")).toBe("\x1b[3;7~");
+  });
+
+  it("resolves all three modifiers combined", () => {
+    expect(resolveKey("ctrl+alt+shift+up")).toBe("\x1b[1;8A");
+    expect(resolveKey("ctrl+alt+shift+return")).toBe("\x1b[13;8u");
   });
 
   it("resolves composed modifiers", () => {


### PR DESCRIPTION
## Summary

- `resolveKey("shift+return")` now correctly produces `\x1b[13;2u` (CSI u encoding) instead of plain `\r`
- CSI sequence keys (arrows, home/end, delete, pageup/down) get the modifier parameter inserted per xterm convention: e.g. `shift+up` → `\x1b[1;2A`, `shift+delete` → `\x1b[3;2~`
- Control char keys (return, tab, escape, space, backspace) use Kitty keyboard protocol CSI u encoding: e.g. `shift+return` → `\x1b[13;2u`
- `shift+tab` produces the legacy backtab sequence `\x1b[Z`
- Combined modifiers (ctrl+shift, alt+shift, ctrl+alt, ctrl+alt+shift) work correctly using the standard xterm modifier bitmask (1 + shift=1 + alt=2 + ctrl=4)

## Rationale

Lines 46-51 of the original `resolveKey` silently ignored shift for non-letter keys, making it impossible to send `shift+return` (needed for e.g. newlines in chat UIs) or `shift+arrow` (needed for text selection). The CSI u encoding from the Kitty keyboard protocol is the standard way to represent these modified keys.

## Test plan

- [x] All existing `keys.test.ts` tests continue to pass
- [x] Added tests for shift+return, shift+enter, shift+tab, shift+escape, shift+space, shift+backspace
- [x] Added tests for shift+arrow keys and shift+navigation keys
- [x] Added tests for combined modifiers (ctrl+shift, alt+shift, ctrl+alt, ctrl+alt+shift)

Fixes #13

---
> [!NOTE]
> This PR was authored by an AI agent acting on behalf of @schickling.

🤖 Generated with [Claude Code](https://claude.com/claude-code)