### PR TITLE
split pty client and server exports

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@
 
 ### Exports
 - Add `@myobie/pty/protocol` subpath export for browser-safe access to the wire protocol types (`PacketReader`, `MessageType`, encode/decode helpers) without pulling in Node-only dependencies (#11, thanks @schickling)
+- Split `PtyServer` out of `@myobie/pty/client` and expose it from `@myobie/pty/server` so client-only imports stay compile-safe
 
 ## 0.5.0
 

--- a/README.md
+++ b/README.md
@@ -141,6 +141,7 @@ import {
   EventFollower, readRecentEvents,
   resolveKey,
 } from "@myobie/pty/client";
+import { PtyServer } from "@myobie/pty/server";
 ```
 
 ### Managing sessions

--- a/docs/client.md
+++ b/docs/client.md
@@ -4,6 +4,7 @@ Import from `@myobie/pty/client`.
 
 ```typescript
 import { SessionConnection, spawnDaemon, listSessions } from "@myobie/pty/client";
+import { PtyServer } from "@myobie/pty/server";
 ```
 
 ## Session Management
@@ -97,12 +98,12 @@ Resolve a command name to an absolute path (like `which`). Throws if not found.
 
 Wait for a session's Unix socket to appear on disk.
 
-### `PtyServer`
+### `@myobie/pty/server`
 
-The server class itself, for embedding a pty server directly (without the daemon process):
+Import the server class from `@myobie/pty/server` when you need to embed a pty server directly:
 
 ```typescript
-import { PtyServer } from "@myobie/pty/client";
+import { PtyServer } from "@myobie/pty/server";
 
 const server = new PtyServer({
   name: "embedded",

--- a/package.json
+++ b/package.json
@@ -42,6 +42,10 @@
       "types": "./dist/client-api.d.ts",
       "default": "./dist/client-api.js"
     },
+    "./server": {
+      "types": "./dist/server.d.ts",
+      "default": "./dist/server.js"
+    },
     "./protocol": {
       "types": "./dist/protocol.d.ts",
       "default": "./dist/protocol.js"

--- a/src/client-api.ts
+++ b/src/client-api.ts
@@ -1,5 +1,6 @@
 // Public API for programmatic session management.
 // Import from "@myobie/pty/client".
+// Import `PtyServer` from "@myobie/pty/server" when you need the server class.
 
 // Session management
 export {
@@ -11,7 +12,6 @@ export {
 
 // Session creation
 export { spawnDaemon, resolveCommand, waitForSocket, type SpawnDaemonOptions } from "./spawn.ts";
-export { PtyServer, type ServerOptions } from "./server.ts";
 
 // Session interaction (programmatic — no process.exit, no stdin/stdout)
 export {

--- a/tests/client-api-compile.test.ts
+++ b/tests/client-api-compile.test.ts
@@ -1,0 +1,43 @@
+import { describe, it, expect } from "vitest";
+import * as fs from "node:fs";
+import * as os from "node:os";
+import * as path from "node:path";
+import { fileURLToPath } from "node:url";
+import { spawnSync } from "node:child_process";
+
+const repoRoot = path.join(path.dirname(fileURLToPath(import.meta.url)), "..");
+const clientApi = path.join(repoRoot, "src", "client-api.ts");
+
+describe("client API compile safety", () => {
+  it("bun-compiles a client-only import without pulling server-only native code", () => {
+    const tempRoot = fs.mkdtempSync(path.join(os.tmpdir(), "pty-client-compile-"));
+    const entryPath = path.join(tempRoot, "entry.ts");
+    const binaryPath = path.join(tempRoot, "entry");
+    try {
+      fs.writeFileSync(
+        entryPath,
+        `import { listSessions } from ${JSON.stringify(clientApi)};\nconsole.log(typeof listSessions);\n`
+      );
+
+      const build = spawnSync("bun", ["build", "--compile", "--outfile", binaryPath, entryPath], {
+        cwd: tempRoot,
+        encoding: "utf-8",
+      });
+
+      if (build.status !== 0) {
+        throw new Error(`bun build failed:\n${build.stdout}${build.stderr}`);
+      }
+
+      const run = spawnSync(binaryPath, [], {
+        cwd: tempRoot,
+        encoding: "utf-8",
+      });
+
+      expect(run.status).toBe(0);
+      expect(run.stdout.trim()).toBe("function");
+      expect(run.stderr.trim()).toBe("");
+    } finally {
+      fs.rmSync(tempRoot, { recursive: true, force: true });
+    }
+  });
+});


### PR DESCRIPTION
This splits `PtyServer` out of `@myobie/pty/client` and exposes it from `@myobie/pty/server` instead.

Why:
- `@myobie/pty/client` was pulling server-only code into client-only imports, which made Bun-compiled consumers resolve native/server dependencies eagerly.
- That broke compile-safety for downstream users that only need the client API.

What changed:
- Added a public `./server` export.
- Removed `PtyServer` from `./client`.
- Updated the README and `docs/client.md` to import `PtyServer` from `@myobie/pty/server`.
- Added a regression test that Bun-compiles a client-only import and verifies it runs without dragging in server-only code.

Validation:
- `npm run build`
- `npm test -- --run tests/client-api-compile.test.ts`
- `git diff --check`
- `npm run typecheck` currently fails on a pre-existing issue in `tests/nesting.test.ts` (`PTY_SESSION` missing from the typed env shape)
- `npm run verify-docs` currently times out on an existing `docs/testing.md` example in generated docs verification

Rationale:
- This keeps the client surface compile-safe by construction instead of relying on bundler behavior or downstream workarounds.
