### PR TITLE
fix: resolve sendData on 'finish' instead of 'close'

### DIFF
--- a/src/client.ts
+++ b/src/client.ts
@@ -176,7 +176,7 @@ export function send(options: SendOptions): void {
     process.exit(1);
   });
 
-  socket.on("close", () => {
+  socket.on("finish", () => {
     process.exit(0);
   });
 }

--- a/tests/integration.test.ts
+++ b/tests/integration.test.ts
@@ -1098,4 +1098,32 @@ describe("integration", () => {
       client2.destroy();
     });
   }
+
+  it("send-style DATA socket resolves 'finish' promptly without waiting for server FIN", async () => {
+    const name = uniqueName();
+    await startServer(name, "cat");
+
+    // Simulate the send() pattern: connect, write DATA packets, end, wait for 'finish'.
+    // This must resolve quickly — if it hangs, the socket is waiting for the server
+    // to send FIN ('close' event) which is unreliable in some container environments.
+    const socketPath = getSocketPath(name);
+    const start = Date.now();
+    const result = await Promise.race([
+      new Promise<"ok">((resolve, reject) => {
+        const socket = net.createConnection(socketPath);
+        socket.on("connect", () => {
+          socket.write(encodeData("hello from send\n"));
+          socket.end();
+        });
+        socket.on("finish", () => resolve("ok"));
+        socket.on("error", reject);
+      }),
+      new Promise<"timeout">((resolve) => setTimeout(() => resolve("timeout"), 3000)),
+    ]);
+    const elapsed = Date.now() - start;
+
+    expect(result).toBe("ok");
+    // 'finish' should fire almost immediately after socket.end(), not after 3s timeout
+    expect(elapsed).toBeLessThan(2000);
+  });
 });


### PR DESCRIPTION
## Summary

- Fix `send()` hanging in Linux namespace containers by resolving on `'finish'` instead of `'close'`

## Problem

`send()` in `src/client.ts` resolves its promise on the socket `'close'` event. `'close'` requires both sides to send FIN (full bidirectional TCP close). In Linux namespace containers (e.g. Namespace.so CI runners), the server's automatic FIN via `allowHalfOpen: false` is unreliable — the server never sends its FIN back, so `'close'` never fires and `send()` hangs until timeout.

## Fix

Changed the event from `'close'` to `'finish'`. `'finish'` fires when our `socket.end()` call has been flushed to the OS kernel, which is sufficient for Unix domain sockets — there's no need to wait for the server's FIN.

Fixes #18

---

> Created on behalf of @schickling