### PR TITLE
fix(client): re-export setServerModulePath from ./client subpath

### DIFF
--- a/src/client-api.ts
+++ b/src/client-api.ts
@@ -12,7 +12,7 @@ export {
 } from "./sessions.ts";
 
 // Session creation
-export { spawnDaemon, resolveCommand, waitForSocket, type SpawnDaemonOptions } from "./spawn.ts";
+export { spawnDaemon, resolveCommand, waitForSocket, setServerModulePath, type SpawnDaemonOptions } from "./spawn.ts";
 
 // Session interaction (programmatic — no process.exit, no stdin/stdout)
 export {


### PR DESCRIPTION
## Summary

`@myobie/pty/client` already re-exports `spawnDaemon`, which delegates to a module-level `_serverModulePath` set by `setServerModulePath(p)`. The escape hatch exists exactly so consumers can override the resolved path when `import.meta.url` doesn't yield a real on-disk location — e.g. when `@myobie/pty` is bundled into a single-file binary by `bun build --compile`.

`setServerModulePath` is currently not re-exported from any public subpath, so consumers either have to deep-import `@myobie/pty/dist/spawn.js` (which the `exports` field forbids — Bun rejects it) or carry a patch on the package.

This PR adds the missing re-export. One-line change, no behavior change.

## Consumer

Lets `forge` in [`schickling/dotfiles#836`](https://github.com/schickling/dotfiles/pull/836) drop the patch it's carrying for exactly this.

## Test plan

- [x] `tsc -p tsconfig.build.json` clean
- [x] `vitest run` — all unrelated failures (vim/zsh env-dependent) were already present on `main`

<!-- agent-footer:begin v=1 -->
<details>
<summary>Posted on behalf of @schickling</summary>

| field | value |
| --- | --- |
| `agent_name` | 🌸 cl2-glade |
| `agent_session_id` | 246b956a-0258-4209-8265-143eb77329b1 |
| `agent_tool` | Claude Code |
| `agent_tool_version` | 2.1.121 |
| `agent_runtime` | Claude Code 2.1.121 |
| `agent_model` | claude-opus-4-7 |
| `worktree` | pty/fix/client-api-export-setServerModulePath |
| `machine` | dev3 |
| `tooling_profile` | dotfiles@unknown-dirty |
</details>
<!-- agent-footer:end -->