### PR TITLE
fix: import xterm serialize addon as ESM namespace

### DIFF
--- a/src/server.ts
+++ b/src/server.ts
@@ -2,12 +2,12 @@ import * as net from "node:net";
 import * as fs from "node:fs";
 import { execFileSync } from "node:child_process";
 import * as pty from "node-pty";
-// @xterm packages are CJS-only. Named imports fail under Node's native ESM
-// loader (Node v24+), so we use default imports + separate type imports.
+// @xterm/headless is CJS-only, so keep its default import. The serialize addon
+// ships native ESM with named exports, so import its runtime namespace.
 import type { Terminal } from "@xterm/headless";
 import type { SerializeAddon } from "@xterm/addon-serialize";
 import xterm from "@xterm/headless";
-import xtermSerialize from "@xterm/addon-serialize";
+import * as xtermSerialize from "@xterm/addon-serialize";
 import {
   MessageType,
   PacketReader,

--- a/src/testing/session.ts
+++ b/src/testing/session.ts
@@ -2,7 +2,7 @@ import * as net from "node:net";
 import type { Terminal } from "@xterm/headless";
 import type { SerializeAddon } from "@xterm/addon-serialize";
 import xterm from "@xterm/headless";
-import xtermSerialize from "@xterm/addon-serialize";
+import * as xtermSerialize from "@xterm/addon-serialize";
 import * as pty from "node-pty";
 import { PtyServer, type ServerOptions as PtyServerOptions } from "../server.ts";
 import {


### PR DESCRIPTION
## Summary

- import `@xterm/addon-serialize` as a namespace in the server and testing session runtime paths
- keep the `@xterm/headless` default import, since that package still needs the CJS-compatible import shape
- update the nearby comment to document the current ESM/CJS split

## Why

`@xterm/addon-serialize@0.14.0` ships a native ESM entry with named exports such as `SerializeAddon`. The default runtime import compiles, but bundled ESM consumers can fail with a missing default export when Rollup/Vite statically analyzes the dependency graph.

## Validation

- `npm run build`
- `node -e "await import('./dist/server.js'); await import('./dist/testing/session.js'); console.log('esm import smoke ok')"`

Note: `npm run typecheck` currently fails on existing test fixture type errors unrelated to this change (`PTY_SESSION` fixture env shape and missing `quit`/`focus` fields in `tests/tui-framework.test.ts`).

<!-- agent-footer:begin v=1 -->
<details>
<summary>Posted on behalf of @schickling</summary>

| field | value |
| --- | --- |
| `agent_name` | 🌕 co4-lunar |
| `agent_session_id` | ce15bada-753e-42c9-b3a1-abdb15d99399 |
| `agent_tool` | Codex CLI |
| `agent_tool_version` | 0.141.0 |
| `agent_runtime` | Codex CLI 0.141.0 |
| `agent_model` | unknown |
| `runtime_profile` | /nix/store/ri1wraif9cqyw420wd1ngp0z0a8rnwn7-coding-agent-runtime-profile/share/coding-agents/profile.json |
| `skills_manifest` | /nix/store/n77xdlvsmwmg1b0kafxnir498z81ijkz-agent-skills-corpus/share/agent-skills/manifest.json |
| `worktree` | pty/schickling-assistant/2026-06-25-fix-xterm-addon-serialize-esm-import |
| `machine` | dev3 |
| `tooling_profile` | dotfiles@unknown-dirty |
</details>
<!-- agent-footer:end -->