### PR TITLE
chore(mcp): migrate to st (Phase 4 of coord→smalltalk/st rename)

### DIFF
--- a/.mcp.json
+++ b/.mcp.json
@@ -1,8 +1,8 @@
 {
   "mcpServers": {
-    "coord": {
+    "st": {
       "type": "stdio",
-      "command": "/Volumes/SSD/src/github.com/myobie/coord/bin/coord",
+      "command": "/Volumes/SSD/src/github.com/myobie/coord/bin/st",
       "args": ["mcp", "--channel"],
       "env": {}
     }


### PR DESCRIPTION
## Summary

pty's Phase 4 of the brief-005 coord→smalltalk/st rename. Opts pty into the canonical MCP server name (\`st\`) and binary path (\`bin/st\`) now that coord PR #14 has shipped the 5-alias backward-compat layer.

Both old and new names continue to work — the alias guarantees in coord's Phase 0 cover the transition. This PR just flips pty's git-tracked config over.

## What changes

- \`.mcp.json\`: server name \`coord\` → \`st\`; binary path \`bin/coord\` (back-compat shim) → \`bin/st\` (canonical).

That's the whole git-tracked surface. Local-only (gitignored) changes on each machine:

- \`pty.toml\` \`[sessions.claude.env]\`: \`COORD_IDENTITY\` → \`ST_IDENTITY\`.
- \`pty.toml\` command: \`--dangerously-load-development-channels server:coord\` → \`server:st\`.
- \`.claude/settings.local.json\` hook paths stay at \`/Volumes/SSD/.../coord/examples/...\` — they'll resolve via the Phase 2 directory symlink once coord-claude does the repo rename.

I've already applied the pty.toml change on this machine; takes effect on next pty-claude restart.

## Why now

- coord PR #14 merged at 2026-06-26T15:55:21Z, shipping all 5 alias guarantees.
- Phase 1 (state-dir move + symlink) completed: \`~/.local/state/coord\` → \`smalltalk\` + symlink. All running agents continue to work via redirection.
- This is the leaf-first dependency ordering from the migration plan: leaf agents migrate first (pty is one of them), \`cos\` is last.

## Test plan

- [ ] CI green (no test surface changes).
- [ ] After merge + pty-claude restart, my MCP server registers as \`st\` (not \`coord\`).
- [ ] All \`coord_*\` tools keep working until Phase 5 cleanup (alias mode).
- [ ] \`st_*\` tools also work.

No-autopush rule applies — Nathan reviews + merges.

— pty-claude (brief-005 Phase 4)