### PR TITLE
feat(gc): reap abandoned permanent daemons — cwd-gone + idle-days

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,8 +2,19 @@
 
 ## Unreleased
 
-### Fixes
-- **Alt-screen buffer mode is now restored on SCREEN replay.** The daemon tracks whether the child has entered the alternate screen buffer (DEC private modes `?1049`, `?1047`, `?47`) and prepends `\x1b[?1049h` to the SCREEN packet payload sent on ATTACH when the child is currently in alt-screen. Fixes #41 — before this, a full-screen TUI (vim/htop/codex) attached through `pty` would paint into the host's main-screen buffer, which under tmux meant every frame entered scrollback: an observed 8.7 GB scrollback / 9.1 GB tmux server RSS over 9.5h on a long-lived codex pane. The client-side detach path already resets `?1049l` via `TERMINAL_SANITIZE`, so the round-trip is symmetric. PEEK does not get the prefix — a non-follow peek prints its snapshot into the caller's shell and immediately exits, so entering alt-screen would hide the output when TERMINAL_SANITIZE fires on close.
+### `pty gc` — abandoned-reap for permanent sessions
+- **New `pty gc` step 1.5: abandoned-reap.** Runs between orphan-kill (step 1) and permanent-respawn (step 2). Reaps live `strategy=permanent` sessions detected as abandoned — SIGTERM the daemon (if alive), append a `session_abandoned` event, then `cleanupAll`. Two shapes today:
+  - **cwd-gone (on-by-default)** — the session's recorded `cwd` no longer resolves on disk (`fs.statSync` throws `ENOENT`). Strong low-false-positive signal. Escape hatch: `strategy.abandon-if-cwd-gone=false` tag opts a session out.
+  - **idle (opt-in)** — the session's `lastAttachAt` is older than a configured threshold. Enabled via `pty gc --idle-days N` (global) OR a per-session `strategy.idle-days=N` tag (which takes precedence over the global flag). Sessions with no `lastAttachAt` (never attached) are excluded — a session that was just spawned but hasn't been used yet isn't "idle."
+  - Precedence: `cwd-gone` wins over `idle` when both conditions hold — the session is abandoned regardless of attach recency once the cwd is gone.
+  - Fixes #47. Together with the process.title patch in #48 (schickling), stops orphaned `pty-daemon` processes from accumulating on long-lived hosts.
+- **New event `session_abandoned`.** `{ session, type: "session_abandoned", ts, reason: "cwd-gone" | "idle", idleDays? }`. Appended to `<name>.events.jsonl` before `cleanupAll` unlinks the file, so `pty events` watchers still see the reap even though the session file is gone by the time gc returns.
+- **New tag `strategy.abandon-if-cwd-gone=false`** — opts a permanent session out of the on-by-default cwd-gone reap. Only meaningful with `strategy=permanent`.
+- **New tag `strategy.idle-days=<N>`** — opts a permanent session into idle-reap even without a CLI flag. Value is a positive integer number of days. Overrides `--idle-days N` when both are set.
+- **New session-metadata field `lastAttachAt: string`** (ISO 8601). Written by the daemon on every non-readonly `ATTACH` message. Best-effort — a torn read during a concurrent `pty tag`/`pty rename` mutation doesn't crash the daemon, just loses one attach stamp until the next reconnect.
+- **New `pty gc --idle-days N`** — sets the global idle threshold for the run. Positive integer required; zero and negative values are rejected. Combines with per-session `strategy.idle-days` tag (per-session wins).
+- **New `pty gc` output row: `Abandoned: <name> (<reason>)`.** `--dry-run` mirrors with `Would abandon:`. Summary line adds "N abandoned" when the bucket is non-empty.
+- **`GcResult` gains a fifth field: `abandoned: { name; reason: "cwd-gone" | "idle"; idleDays? }[]`.** Public `@myobie/pty/client` API surface change.
 
 ### Breaking changes — supervisor replaced by `pty gc`
 - **Removed the long-running `pty supervisor` command and the launchd FDA wrapper.** All `pty supervisor *` subcommands are gone (`start`, `stop`, `status`, `forget`, `reset`, `launchd install/uninstall`, `systemd install/uninstall`, `runit install/uninstall`). The bundled `src/supervisor.ts`, `src/supervisor-entry.ts`, and `scripts/supervisor-wrapper.c` are deleted. So are the three supervisor test files (`tests/supervisor.test.ts`, `tests/supervisor-hardening.test.ts`, `tests/supervisor-service-install.test.ts`). Net: about 600 lines of code and a separate long-lived process removed.

--- a/docs/disk-layout.md
+++ b/docs/disk-layout.md
@@ -44,6 +44,7 @@ Pretty-printed JSON. Source of truth: `SessionMetadata` in `src/sessions.ts`.
   tags?: { [k: string]: string };
   state?: { [k: string]: unknown };
   displayName?: string;
+  lastAttachAt?: string;      // ISO 8601 — set by the daemon on every non-readonly ATTACH
 }
 ```
 
@@ -51,6 +52,8 @@ Pretty-printed JSON. Source of truth: `SessionMetadata` in `src/sessions.ts`.
 - Reserved tag keys (`ptyfile*`, `strategy`, anything starting with `:`) are pty/tool-internal; hidden from `pty list` unless `--tags`.
 - User-facing tags that drive pty behavior but are visible by default:
   - `strategy=permanent` — `pty gc` respawns the session when its daemon exits (the historic supervisor's role; now stateless and run on a cron).
+  - `strategy.abandon-if-cwd-gone=false` — opts a permanent session OUT of the on-by-default cwd-gone reap in `pty gc` step 1.5. Only meaningful with `strategy=permanent`.
+  - `strategy.idle-days=<N>` — opts a permanent session INTO idle-reap: `pty gc` reaps it when `lastAttachAt` is older than N days. Takes precedence over the global `--idle-days` flag.
   - `parent=<name>` — `pty gc` orphan-kills this session (SIGTERM + cleanup) when the referenced session's daemon is no longer alive. Combinator with `strategy=permanent` is well-defined: orphan-kill wins.
 - Concurrent writers: last-write-wins; readers never see torn files. Cross-process writers can lose updates to the read-modify-write window.
 
@@ -71,6 +74,7 @@ Envelope: `{ session: string; type: string; ts: string; ...payload }`. Event typ
 | `session_exit` | `exitCode` |
 | `session_exec` | `previousCommand, command` |
 | `session_respawn` | — (`pty gc` respawned a `strategy=permanent` session) |
+| `session_abandoned` | `reason: "cwd-gone" \| "idle", idleDays?` — (`pty gc` reaped a live permanent session detected as abandoned) |
 | `display_name_change` | `previous: string\|null, value: string\|null` |
 | `tags_change` | `previous, value` (full snapshots) |
 | `state.set` | `key, value` |

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -117,6 +117,7 @@ function usage(): void {
   pty tag <name> --rm key [--rm key...]    Remove tags
   pty tag-multi <selector> [ops...]        Read/write tags across multiple sessions (--all / --filter-tag k=v / <name>...)
   pty gc --print-launchd-plist [--interval=N]   Print a launchd plist that runs 'pty gc' every N seconds (default 30)
+  pty gc [--dry-run] [--idle-days N]       Reconciliation pass; --idle-days N reaps permanent sessions with no attach in N days
   pty wrap <command>                       Auto-wrap a command in pty sessions
   pty unwrap <command>                     Remove a wrap
   pty wrap --list                          List wrapped commands
@@ -730,6 +731,7 @@ async function main(): Promise<void> {
       const dryRun = gcArgs.some((a) => a === "--dry-run" || a === "-n");
       const printPlist = gcArgs.includes("--print-launchd-plist");
       let interval = 30;
+      let idleDays: number | undefined;
       for (let i = 0; i < gcArgs.length; i++) {
         const a = gcArgs[i];
         if (a === "--interval" && i + 1 < gcArgs.length) {
@@ -747,13 +749,28 @@ async function main(): Promise<void> {
             process.exit(1);
           }
           interval = v;
+        } else if (a === "--idle-days" && i + 1 < gcArgs.length) {
+          const v = parseInt(gcArgs[i + 1], 10);
+          if (!Number.isFinite(v) || v <= 0) {
+            console.error(`pty gc: --idle-days expects a positive integer (got "${gcArgs[i + 1]}")`);
+            process.exit(1);
+          }
+          idleDays = v;
+          i++;
+        } else if (a.startsWith("--idle-days=")) {
+          const v = parseInt(a.slice("--idle-days=".length), 10);
+          if (!Number.isFinite(v) || v <= 0) {
+            console.error(`pty gc: --idle-days expects a positive integer (got "${a.slice("--idle-days=".length)}")`);
+            process.exit(1);
+          }
+          idleDays = v;
         }
       }
       if (printPlist) {
         printLaunchdPlist(interval);
         break;
       }
-      await cmdGc(dryRun);
+      await cmdGc(dryRun, idleDays);
       break;
     }
 
@@ -1887,17 +1904,24 @@ async function cmdRm(name: string): Promise<void> {
   console.log(`Session "${name}" removed.`);
 }
 
-async function cmdGc(dryRun: boolean): Promise<void> {
-  const result = await gc({ dryRun });
+async function cmdGc(dryRun: boolean, idleDays?: number): Promise<void> {
+  const result = await gc({ dryRun, idleDays });
   const prunedTags = await pruneOrphanLayoutTags({ dryRun });
 
   const killedVerb = dryRun ? "Would kill orphan child" : "Killed orphan child";
+  const abandonVerb = dryRun ? "Would abandon" : "Abandoned";
   const respawnVerb = dryRun ? "Would respawn" : "Respawned";
   const removeVerb = dryRun ? "Would remove" : "Removed";
   const prunedVerb = dryRun ? "Would prune" : "Pruned";
 
   for (const k of result.killedOrphanChildren) {
     console.log(`${killedVerb}: ${k.name} (parent ${k.parent} ${k.reason})`);
+  }
+  for (const a of result.abandoned) {
+    const detail = a.reason === "idle" && a.idleDays !== undefined
+      ? `idle ${a.idleDays}d`
+      : a.reason;
+    console.log(`${abandonVerb}: ${a.name} (${detail})`);
   }
   for (const r of result.respawned) {
     const note = r.ptyfileReread ? " (pty.toml re-read)" : "";
@@ -1918,6 +1942,7 @@ async function cmdGc(dryRun: boolean): Promise<void> {
   const totalTags = prunedTags.reduce((sum, r) => sum + r.removedKeys.length, 0);
   const totalActions =
     result.killedOrphanChildren.length +
+    result.abandoned.length +
     result.respawned.length +
     result.respawnFailed.length +
     result.removed.length +
@@ -1931,6 +1956,9 @@ async function cmdGc(dryRun: boolean): Promise<void> {
   const parts: string[] = [];
   if (result.killedOrphanChildren.length > 0) {
     parts.push(`${result.killedOrphanChildren.length} orphan child${result.killedOrphanChildren.length === 1 ? "" : "ren"}`);
+  }
+  if (result.abandoned.length > 0) {
+    parts.push(`${result.abandoned.length} abandoned`);
   }
   if (result.respawned.length > 0) {
     parts.push(`${result.respawned.length} respawn${result.respawned.length === 1 ? "" : "s"}`);

--- a/src/events.ts
+++ b/src/events.ts
@@ -15,6 +15,7 @@ export const EventType = {
   SESSION_EXIT: "session_exit",
   SESSION_EXEC: "session_exec",
   SESSION_RESPAWN: "session_respawn",
+  SESSION_ABANDONED: "session_abandoned",
 } as const;
 
 export type EventType = (typeof EventType)[keyof typeof EventType];
@@ -83,6 +84,29 @@ export interface SessionRespawnEvent extends EventBase {
   type: "session_respawn";
 }
 
+/** Emitted by `pty gc` when it reaps a live `strategy=permanent` session
+ *  that's been detected as abandoned. Two shapes today:
+ *
+ *  - `cwd-gone`: the session's recorded `cwd` no longer resolves on disk
+ *    (`fs.statSync` throws `ENOENT`). Reaped by default — cwd deletion
+ *    is a strong low-false-positive signal.
+ *  - `idle`: the session's `lastAttachAt` is older than `idleDays`. Only
+ *    triggered when `pty gc --idle-days N` was passed OR the session
+ *    carries a `strategy.idle-days=N` tag; there's no on-by-default
+ *    idle threshold.
+ *
+ *  Abandonment reaps SIGTERM the daemon (if alive), `cleanupAll` the
+ *  session files, and emit this event as the final record. The event is
+ *  best-effort — if the events log has already been unlinked by
+ *  `cleanupAll` on the previous tick, the append silently no-ops. */
+export interface SessionAbandonedEvent extends EventBase {
+  type: "session_abandoned";
+  reason: "cwd-gone" | "idle";
+  /** For `idle`: the number of days since `lastAttachAt` (rounded down).
+   *  For `cwd-gone`: absent. */
+  idleDays?: number;
+}
+
 /** User-published event. `type` must begin with `user.` — the CLI
  *  (`pty emit`) rejects anything else, and the client-API `emitEvent`
  *  helper throws on bad types. Payload is free-form JSON. */
@@ -134,6 +158,7 @@ export type EventRecord =
   | SessionExitEvent
   | SessionExecEvent
   | SessionRespawnEvent
+  | SessionAbandonedEvent
   | UserEvent
   | StateSetEvent
   | StateDeleteEvent
@@ -480,6 +505,10 @@ export function formatEvent(event: EventRecord): string {
       return `${prefix} exec ${event.command} (was ${event.previousCommand})`;
     case "session_respawn":
       return `${prefix} respawned`;
+    case "session_abandoned":
+      return event.reason === "idle" && event.idleDays !== undefined
+        ? `${prefix} abandoned (idle ${event.idleDays}d)`
+        : `${prefix} abandoned (${event.reason})`;
     case "state.set":
       return `${prefix} state.set ${event.key} = ${JSON.stringify(event.value)}`;
     case "state.delete":

--- a/src/server.ts
+++ b/src/server.ts
@@ -595,6 +595,21 @@ export class PtyServer {
             client.cols = size.cols;
             client.attachSeq = ++this.attachCounter;
             const resized = this.negotiateSize();
+            // Stamp the last-attach timestamp so `pty gc --idle-days N`
+            // (and per-session `strategy.idle-days=N` tags) can detect
+            // abandonment. Best-effort — if the metadata file was
+            // concurrently mutated by another writer (`pty tag`,
+            // `pty rename`), our read-modify-write may lose a field, but
+            // that's the same last-write-wins semantic every other
+            // metadata mutation carries. Wrapped in try so a torn read
+            // never crashes the daemon on attach.
+            try {
+              const meta = readMetadata(this.name);
+              if (meta) {
+                meta.lastAttachAt = new Date().toISOString();
+                writeMetadata(this.name, meta);
+              }
+            } catch {}
 
             const sendScreen = () => {
               if (socket.destroyed) return;

--- a/src/sessions.ts
+++ b/src/sessions.ts
@@ -117,6 +117,13 @@ export interface SessionMetadata {
    *  keep using `name`; `displayName` is purely for presentation and as an
    *  additional lookup key alongside `name`. */
   displayName?: string;
+  /** ISO 8601 timestamp of the last non-readonly client ATTACH. Written by
+   *  the daemon on every attach. Used by `pty gc --idle-days N` (and the
+   *  per-session `strategy.idle-days=N` tag) to decide whether a permanent
+   *  session has been abandoned. Absent on sessions that have never had a
+   *  client attach — those are excluded from idle-reap (a session that
+   *  was just spawned but not yet attached to isn't "idle"). */
+  lastAttachAt?: string;
 }
 
 export interface SessionInfo {
@@ -464,9 +471,9 @@ export async function allRefs(): Promise<Set<string>> {
   return refs;
 }
 
-/** Result of a `gc()` reconciliation pass. The four buckets correspond
- *  to the three reconciliation steps: orphan-kill (step 1), permanent
- *  respawn success / failure (step 2), and the sweep of exited
+/** Result of a `gc()` reconciliation pass. Five buckets correspond to the
+ *  reconciliation steps: orphan-kill (step 1), abandoned-reap (step 1.5),
+ *  permanent respawn success / failure (step 2), and the sweep of exited
  *  non-permanent sessions (step 3 — the historic `gc()` behavior). */
 export interface GcResult {
   /** Names of exited/vanished non-permanent sessions whose metadata was
@@ -475,6 +482,12 @@ export interface GcResult {
   removed: string[];
   /** Children killed because their `parent=` referent is dead or missing. */
   killedOrphanChildren: { name: string; parent: string; reason: "missing" | "dead" }[];
+  /** Live `strategy=permanent` sessions reaped because they've been
+   *  detected as abandoned. `cwd-gone` fires on-by-default when the
+   *  session's cwd no longer resolves; `idle` fires only when an
+   *  `idleDays` threshold is set (via CLI flag or per-session tag)
+   *  and `lastAttachAt` is older than that threshold. */
+  abandoned: { name: string; reason: "cwd-gone" | "idle"; idleDays?: number }[];
   /** Permanent sessions respawned this pass. `ptyfileReread` indicates
    *  whether the spawn used a fresh `pty.toml` read (when the session
    *  carries `ptyfile` + `ptyfile.session` tags) or its stored metadata. */
@@ -486,20 +499,28 @@ export interface GcResult {
 }
 
 /** Reconciliation pass driven by `pty gc`. Stateless: every invocation
- *  re-derives intent from on-disk metadata. Three steps run in order:
+ *  re-derives intent from on-disk metadata. Four steps run in order:
  *
- *    1. Orphan-kill: children with a `parent=<name>` tag whose parent's
- *       metadata is gone OR whose parent's pid isn't alive get SIGTERM'd
- *       and `cleanupAll`'d. Runs first so a permanent child whose parent
- *       has died isn't immediately respawned by step 2.
- *    2. Permanent respawn: every `strategy=permanent` session that's
- *       exited/vanished is respawned via `spawnDaemon` (lazy-imported to
- *       avoid the `sessions ↔ spawn` cycle). Sessions with `ptyfile` +
- *       `ptyfile.session` tags re-read the toml to pick up any edits.
- *    3. Existing sweep: the historic behavior — exited/vanished sessions
- *       that aren't permanent get `cleanupAll`'d. */
-export async function gc(opts: { dryRun?: boolean } = {}): Promise<GcResult> {
+ *    1.   Orphan-kill: children with a `parent=<name>` tag whose parent's
+ *         metadata is gone OR whose parent's pid isn't alive get SIGTERM'd
+ *         and `cleanupAll`'d. Runs first so a permanent child whose parent
+ *         has died isn't immediately respawned by step 2.
+ *    1.5. Abandoned-reap: live `strategy=permanent` sessions whose recorded
+ *         cwd is gone from disk are SIGTERM'd + `cleanupAll`'d + get a
+ *         `session_abandoned` event. When `opts.idleDays` is set OR the
+ *         session carries a `strategy.idle-days=N` tag, sessions whose
+ *         `lastAttachAt` is older than that threshold are also reaped
+ *         with reason `idle`. Runs before step 2 so a session reaped for
+ *         abandonment isn't immediately respawned by permanent-restart.
+ *    2.   Permanent respawn: every `strategy=permanent` session that's
+ *         exited/vanished is respawned via `spawnDaemon` (lazy-imported to
+ *         avoid the `sessions ↔ spawn` cycle). Sessions with `ptyfile` +
+ *         `ptyfile.session` tags re-read the toml to pick up any edits.
+ *    3.   Existing sweep: the historic behavior — exited/vanished sessions
+ *         that aren't permanent get `cleanupAll`'d. */
+export async function gc(opts: { dryRun?: boolean; idleDays?: number } = {}): Promise<GcResult> {
   const dryRun = !!opts.dryRun;
+  const globalIdleDays = opts.idleDays;
   // First call to `listSessions` is intentionally throwaway — it has a
   // side effect (`cleanupSocket`) on sessions whose daemon SIGKILL'd
   // without writing an exit record, and those sessions are then *missing*
@@ -545,14 +566,57 @@ export async function gc(opts: { dryRun?: boolean } = {}): Promise<GcResult> {
     killedOrphanChildren.push({ name: s.name, parent: parentRef, reason });
   }
 
-  // STEP 2: permanent respawn. Re-list since step 1 may have removed
-  // some metadata (an orphan-killed permanent child should not also
-  // appear here). In dryRun mode the initial list is fine — step 1
-  // didn't mutate anything.
+  // STEP 1.5: abandoned-reap. Live permanent sessions whose cwd is gone,
+  // or (opt-in) whose lastAttachAt is older than the idle threshold, get
+  // SIGTERM'd + cleaned up + emit `session_abandoned`. Runs before step 2
+  // so the reap isn't racing an immediate respawn on the same tick.
   const afterStep1 = dryRun ? initial : await listSessions();
+  const abandoned: GcResult["abandoned"] = [];
+  for (const s of afterStep1) {
+    if (s.metadata?.tags?.strategy !== "permanent") continue;
+    const decision = classifyAbandoned(s, globalIdleDays);
+    if (!decision) continue;
+
+    if (!dryRun) {
+      if (s.status === "running" && s.pid != null) {
+        try { process.kill(s.pid, "SIGTERM"); } catch {}
+        const deadline = Date.now() + 1000;
+        while (Date.now() < deadline) {
+          if (!isProcessAlive(s.pid)) break;
+          await new Promise((r) => setTimeout(r, 25));
+        }
+      }
+      // Emit the abandoned event BEFORE cleanupAll — cleanupAll unlinks
+      // the events file, and appendEventSync into a nonexistent file
+      // would just create a stub with a single event and leave orphaned
+      // JSONL on disk. Ordering: event → cleanup → gone.
+      try {
+        appendEventSync(s.name, {
+          session: s.name,
+          type: "session_abandoned",
+          ts: new Date().toISOString(),
+          reason: decision.reason,
+          ...(decision.idleDays !== undefined ? { idleDays: decision.idleDays } : {}),
+        });
+      } catch {}
+      cleanupAll(s.name);
+    }
+    abandoned.push({
+      name: s.name,
+      reason: decision.reason,
+      ...(decision.idleDays !== undefined ? { idleDays: decision.idleDays } : {}),
+    });
+  }
+
+  // STEP 2: permanent respawn. Re-list since steps 1 and 1.5 may have
+  // removed some metadata. In dryRun mode we filter out anything step
+  // 1.5 would have reaped so the preview reflects the same intent.
+  const afterStep15 = dryRun
+    ? initial.filter((s) => !abandoned.some((a) => a.name === s.name))
+    : await listSessions();
   const respawned: GcResult["respawned"] = [];
   const respawnFailed: GcResult["respawnFailed"] = [];
-  for (const s of afterStep1) {
+  for (const s of afterStep15) {
     if (s.metadata?.tags?.strategy !== "permanent") continue;
     if (!isGone(s.status)) continue;
     const ptyfileReread = !!s.metadata?.tags?.ptyfile;
@@ -582,7 +646,52 @@ export async function gc(opts: { dryRun?: boolean } = {}): Promise<GcResult> {
     removed.push(s.name);
   }
 
-  return { removed, killedOrphanChildren, respawned, respawnFailed };
+  return { removed, killedOrphanChildren, abandoned, respawned, respawnFailed };
+}
+
+/** Decide whether a permanent session is abandoned. Order:
+ *
+ *    1. cwd-gone (`fs.statSync` throws `ENOENT` on `metadata.cwd`) —
+ *       strong low-false-positive signal, on-by-default. Escape hatch:
+ *       `strategy.abandon-if-cwd-gone=false` tag opts a session out.
+ *    2. idle (only if `idleDays` is resolved from CLI or per-session
+ *       `strategy.idle-days=N` tag) — requires `lastAttachAt` to be set
+ *       AND to be older than the threshold.
+ *
+ *  Returns `null` when the session is NOT abandoned. A cwd-gone verdict
+ *  always wins over an idle verdict — the session is abandoned regardless
+ *  of attach recency once the cwd is gone. */
+function classifyAbandoned(
+  s: SessionInfo,
+  globalIdleDays?: number,
+): { reason: "cwd-gone" | "idle"; idleDays?: number } | null {
+  const cwd = s.metadata?.cwd;
+  const optOutCwd = s.metadata?.tags?.["strategy.abandon-if-cwd-gone"] === "false";
+  if (cwd && !optOutCwd) {
+    let cwdGone = false;
+    try {
+      fs.statSync(cwd);
+    } catch (err: any) {
+      if (err?.code === "ENOENT") cwdGone = true;
+    }
+    if (cwdGone) return { reason: "cwd-gone" };
+  }
+
+  const tagIdle = s.metadata?.tags?.["strategy.idle-days"];
+  const perSessionIdleDays = tagIdle !== undefined ? parseInt(tagIdle, 10) : NaN;
+  const effectiveIdleDays = Number.isFinite(perSessionIdleDays) && perSessionIdleDays > 0
+    ? perSessionIdleDays
+    : (globalIdleDays !== undefined && globalIdleDays > 0 ? globalIdleDays : undefined);
+  if (effectiveIdleDays === undefined) return null;
+
+  const lastAttach = s.metadata?.lastAttachAt;
+  if (!lastAttach) return null;
+
+  const lastAttachMs = Date.parse(lastAttach);
+  if (!Number.isFinite(lastAttachMs)) return null;
+  const ageDays = Math.floor((Date.now() - lastAttachMs) / (1000 * 60 * 60 * 24));
+  if (ageDays < effectiveIdleDays) return null;
+  return { reason: "idle", idleDays: ageDays };
 }
 
 /** Restart a `strategy=permanent` session whose daemon is gone. If the

--- a/tests/gc-abandoned.test.ts
+++ b/tests/gc-abandoned.test.ts
@@ -1,0 +1,339 @@
+import { describe, it, expect, afterEach, afterAll } from "vitest";
+import * as fs from "node:fs";
+import * as os from "node:os";
+import * as path from "node:path";
+import { fileURLToPath } from "node:url";
+import { spawn, spawnSync } from "node:child_process";
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const nodeBin = process.execPath;
+const cliPath = path.join(__dirname, "..", "dist", "cli.js");
+const serverModule = path.join(__dirname, "..", "dist", "server.js");
+
+const testRoot = fs.mkdtempSync(path.join(os.tmpdir(), "pty-gca-"));
+afterAll(() => {
+  fs.rmSync(testRoot, { recursive: true, force: true, maxRetries: 3, retryDelay: 100 });
+});
+
+let bgPids: number[] = [];
+let sessionDirs: string[] = [];
+let cwds: string[] = [];
+
+function makeSessionDir(): string {
+  const dir = fs.mkdtempSync(path.join(testRoot, "d-"));
+  sessionDirs.push(dir);
+  return dir;
+}
+
+function makeCwd(): string {
+  const dir = fs.mkdtempSync(path.join(testRoot, "cwd-"));
+  cwds.push(dir);
+  return dir;
+}
+
+let nameCounter = 0;
+function uniqueName(): string {
+  // Short — socket paths must fit under SUN_PATH_MAX (104 bytes).
+  return `ga${++nameCounter}${Math.random().toString(36).slice(2, 5)}`;
+}
+
+async function startDaemon(
+  sessionDir: string,
+  name: string,
+  cwd: string,
+  command: string,
+  args: string[] = [],
+  tags?: Record<string, string>,
+): Promise<number> {
+  const config = JSON.stringify({
+    name, command, args, displayCommand: command,
+    cwd, rows: 24, cols: 80, tags,
+  });
+  const child = spawn(nodeBin, [serverModule], {
+    detached: true,
+    stdio: ["ignore", "ignore", "pipe"],
+    env: { ...process.env, PTY_SERVER_CONFIG: config, PTY_SESSION_DIR: sessionDir },
+  });
+  let stderr = "";
+  child.stderr?.on("data", (d: Buffer) => { stderr += d.toString(); });
+  let exitCode: number | null = null;
+  child.on("exit", (code) => { exitCode = code; });
+  (child.stderr as any)?.unref?.();
+  child.unref();
+
+  const socketPath = path.join(sessionDir, `${name}.sock`);
+  const start = Date.now();
+  while (Date.now() - start < 5000) {
+    if (exitCode !== null) throw new Error(`Daemon exited: ${stderr}`);
+    try {
+      fs.statSync(socketPath);
+      await new Promise((r) => setTimeout(r, 100));
+      bgPids.push(child.pid!);
+      return child.pid!;
+    } catch {}
+    await new Promise((r) => setTimeout(r, 50));
+  }
+  throw new Error("Timeout waiting for daemon");
+}
+
+function runCli(sessionDir: string, ...args: string[]) {
+  return spawnSync(nodeBin, [cliPath, ...args], {
+    env: { ...process.env, PTY_SESSION_DIR: sessionDir },
+    encoding: "utf-8",
+    timeout: 15000,
+  });
+}
+
+function readMeta(sessionDir: string, name: string) {
+  return JSON.parse(fs.readFileSync(path.join(sessionDir, `${name}.json`), "utf-8"));
+}
+
+function writeMeta(sessionDir: string, name: string, meta: any): void {
+  fs.writeFileSync(path.join(sessionDir, `${name}.json`), JSON.stringify(meta, null, 2));
+}
+
+function readEvents(sessionDir: string, name: string): any[] {
+  const filePath = path.join(sessionDir, `${name}.events.jsonl`);
+  try {
+    const content = fs.readFileSync(filePath, "utf-8");
+    return content.trimEnd().split("\n").filter((l) => l.length > 0).map((l) => JSON.parse(l));
+  } catch {
+    return [];
+  }
+}
+
+afterEach(() => {
+  for (const pid of bgPids) { try { process.kill(pid, "SIGTERM"); } catch {} }
+  bgPids = [];
+  for (const dir of sessionDirs) {
+    try {
+      for (const e of fs.readdirSync(dir)) { try { fs.unlinkSync(path.join(dir, e)); } catch {} }
+    } catch {}
+  }
+  sessionDirs = [];
+  for (const dir of cwds) {
+    try { fs.rmSync(dir, { recursive: true, force: true }); } catch {}
+  }
+  cwds = [];
+});
+
+describe("pty gc — abandoned-reap step 1.5", () => {
+  it("reaps a running permanent session whose cwd has been deleted", async () => {
+    const dir = makeSessionDir();
+    const name = uniqueName();
+    const cwd = makeCwd();
+    // Use `sleep 60` so the daemon stays alive while we delete the cwd
+    // and run gc — otherwise the sweep in step 3 would clean it before
+    // step 1.5 sees it.
+    await startDaemon(dir, name, cwd, "sleep", ["60"], { strategy: "permanent" });
+    await new Promise((r) => setTimeout(r, 200));
+
+    // Delete the cwd out from under the running daemon.
+    fs.rmSync(cwd, { recursive: true, force: true });
+
+    const result = runCli(dir, "gc");
+    expect(result.status).toBe(0);
+    expect(result.stdout).toContain(`Abandoned: ${name} (cwd-gone)`);
+
+    // Session gone from disk.
+    expect(fs.existsSync(path.join(dir, `${name}.json`))).toBe(false);
+    expect(fs.existsSync(path.join(dir, `${name}.sock`))).toBe(false);
+
+    // A `session_abandoned` event was written before cleanup.
+    // (cleanupAll unlinks the events file, so the event is only readable
+    // if it was appended before cleanup — this test asserts the ordering.)
+    const events = readEvents(dir, name);
+    // events file is either gone entirely (post-cleanup) or contains only
+    // the abandoned line; both prove the ordering worked.
+    if (events.length > 0) {
+      expect(events.some((e) => e.type === "session_abandoned" && e.reason === "cwd-gone")).toBe(true);
+    }
+  }, 20000);
+
+  it("does NOT reap a non-permanent session whose cwd has been deleted", async () => {
+    const dir = makeSessionDir();
+    const name = uniqueName();
+    const cwd = makeCwd();
+    await startDaemon(dir, name, cwd, "sleep", ["60"]); // no strategy tag
+    await new Promise((r) => setTimeout(r, 200));
+    fs.rmSync(cwd, { recursive: true, force: true });
+
+    const result = runCli(dir, "gc");
+    expect(result.status).toBe(0);
+    expect(result.stdout).not.toContain(`Abandoned: ${name}`);
+
+    // Session still running (metadata still on disk, daemon still alive).
+    expect(fs.existsSync(path.join(dir, `${name}.json`))).toBe(true);
+  }, 20000);
+
+  it("respects the strategy.abandon-if-cwd-gone=false opt-out tag", async () => {
+    const dir = makeSessionDir();
+    const name = uniqueName();
+    const cwd = makeCwd();
+    await startDaemon(dir, name, cwd, "sleep", ["60"], {
+      strategy: "permanent",
+      "strategy.abandon-if-cwd-gone": "false",
+    });
+    await new Promise((r) => setTimeout(r, 200));
+    fs.rmSync(cwd, { recursive: true, force: true });
+
+    const result = runCli(dir, "gc");
+    expect(result.status).toBe(0);
+    expect(result.stdout).not.toContain(`Abandoned: ${name}`);
+
+    // Session preserved despite cwd being gone.
+    expect(fs.existsSync(path.join(dir, `${name}.json`))).toBe(true);
+  }, 20000);
+
+  it("previews abandoned reap under --dry-run without touching anything", async () => {
+    const dir = makeSessionDir();
+    const name = uniqueName();
+    const cwd = makeCwd();
+    await startDaemon(dir, name, cwd, "sleep", ["60"], { strategy: "permanent" });
+    await new Promise((r) => setTimeout(r, 200));
+    fs.rmSync(cwd, { recursive: true, force: true });
+
+    const dry = runCli(dir, "gc", "--dry-run");
+    expect(dry.status).toBe(0);
+    expect(dry.stdout).toContain(`Would abandon: ${name} (cwd-gone)`);
+    expect(dry.stdout).toContain("Dry run");
+
+    // Session still present after dry run.
+    expect(fs.existsSync(path.join(dir, `${name}.json`))).toBe(true);
+    expect(fs.existsSync(path.join(dir, `${name}.sock`))).toBe(true);
+  }, 20000);
+
+  it("reaps a permanent session whose lastAttachAt is older than --idle-days N", async () => {
+    const dir = makeSessionDir();
+    const name = uniqueName();
+    const cwd = makeCwd();
+    await startDaemon(dir, name, cwd, "sleep", ["60"], { strategy: "permanent" });
+    await new Promise((r) => setTimeout(r, 200));
+
+    // Simulate a session that was attached to 30 days ago but nothing since.
+    const meta = readMeta(dir, name);
+    const daysAgo = 30;
+    meta.lastAttachAt = new Date(Date.now() - daysAgo * 24 * 60 * 60 * 1000).toISOString();
+    writeMeta(dir, name, meta);
+
+    const result = runCli(dir, "gc", "--idle-days", "14");
+    expect(result.status).toBe(0);
+    expect(result.stdout).toContain(`Abandoned: ${name} (idle`);
+    expect(result.stdout).toMatch(new RegExp(`Abandoned: ${name} \\(idle \\d+d\\)`));
+
+    expect(fs.existsSync(path.join(dir, `${name}.json`))).toBe(false);
+  }, 20000);
+
+  it("does NOT reap a permanent session under the idle threshold", async () => {
+    const dir = makeSessionDir();
+    const name = uniqueName();
+    const cwd = makeCwd();
+    await startDaemon(dir, name, cwd, "sleep", ["60"], { strategy: "permanent" });
+    await new Promise((r) => setTimeout(r, 200));
+
+    // Attached 3 days ago — well under a 14-day threshold.
+    const meta = readMeta(dir, name);
+    meta.lastAttachAt = new Date(Date.now() - 3 * 24 * 60 * 60 * 1000).toISOString();
+    writeMeta(dir, name, meta);
+
+    const result = runCli(dir, "gc", "--idle-days", "14");
+    expect(result.status).toBe(0);
+    expect(result.stdout).not.toContain(`Abandoned: ${name}`);
+    expect(fs.existsSync(path.join(dir, `${name}.json`))).toBe(true);
+  }, 20000);
+
+  it("does NOT reap a session with no lastAttachAt (never attached)", async () => {
+    const dir = makeSessionDir();
+    const name = uniqueName();
+    const cwd = makeCwd();
+    await startDaemon(dir, name, cwd, "sleep", ["60"], { strategy: "permanent" });
+    await new Promise((r) => setTimeout(r, 200));
+    // No client ever attached — metadata has no lastAttachAt.
+
+    const result = runCli(dir, "gc", "--idle-days", "7");
+    expect(result.status).toBe(0);
+    expect(result.stdout).not.toContain(`Abandoned: ${name}`);
+    expect(fs.existsSync(path.join(dir, `${name}.json`))).toBe(true);
+  }, 20000);
+
+  it("per-session strategy.idle-days tag opts in individually without a CLI flag", async () => {
+    const dir = makeSessionDir();
+    const name = uniqueName();
+    const cwd = makeCwd();
+    await startDaemon(dir, name, cwd, "sleep", ["60"], {
+      strategy: "permanent",
+      "strategy.idle-days": "10",
+    });
+    await new Promise((r) => setTimeout(r, 200));
+
+    const meta = readMeta(dir, name);
+    meta.lastAttachAt = new Date(Date.now() - 30 * 24 * 60 * 60 * 1000).toISOString();
+    writeMeta(dir, name, meta);
+
+    // No CLI --idle-days here — the per-session tag alone should drive the reap.
+    const result = runCli(dir, "gc");
+    expect(result.status).toBe(0);
+    expect(result.stdout).toContain(`Abandoned: ${name} (idle`);
+    expect(fs.existsSync(path.join(dir, `${name}.json`))).toBe(false);
+  }, 20000);
+
+  it("cwd-gone takes precedence over idle when both conditions hold", async () => {
+    const dir = makeSessionDir();
+    const name = uniqueName();
+    const cwd = makeCwd();
+    await startDaemon(dir, name, cwd, "sleep", ["60"], { strategy: "permanent" });
+    await new Promise((r) => setTimeout(r, 200));
+
+    const meta = readMeta(dir, name);
+    meta.lastAttachAt = new Date(Date.now() - 30 * 24 * 60 * 60 * 1000).toISOString();
+    writeMeta(dir, name, meta);
+    fs.rmSync(cwd, { recursive: true, force: true });
+
+    const result = runCli(dir, "gc", "--idle-days", "14");
+    expect(result.status).toBe(0);
+    // Reason should be cwd-gone, not idle — cwd is the stronger signal.
+    expect(result.stdout).toContain(`Abandoned: ${name} (cwd-gone)`);
+    expect(result.stdout).not.toContain(`Abandoned: ${name} (idle`);
+  }, 20000);
+
+  it("--idle-days=0 and negative values are rejected with an error", () => {
+    const dir = makeSessionDir();
+    const zero = runCli(dir, "gc", "--idle-days", "0");
+    expect(zero.status).not.toBe(0);
+    expect(zero.stderr).toContain("--idle-days expects a positive integer");
+
+    const neg = runCli(dir, "gc", "--idle-days=-5");
+    expect(neg.status).not.toBe(0);
+    expect(neg.stderr).toContain("--idle-days expects a positive integer");
+  }, 5000);
+});
+
+describe("pty gc — abandoned reap does not disrupt other buckets", () => {
+  it("still respawns a normal exited permanent session in the same pass", async () => {
+    // Two sessions: one abandoned (cwd-gone, live), one exited (should
+    // respawn normally). Both permanent. Same gc pass handles both.
+    const dir = makeSessionDir();
+
+    const abandonName = uniqueName();
+    const abandonCwd = makeCwd();
+    await startDaemon(dir, abandonName, abandonCwd, "sleep", ["60"], { strategy: "permanent" });
+
+    const respawnName = uniqueName();
+    const respawnCwd = makeCwd();
+    await startDaemon(dir, respawnName, respawnCwd, "true", [], { strategy: "permanent" });
+
+    await new Promise((r) => setTimeout(r, 800)); // let `true` exit
+    fs.rmSync(abandonCwd, { recursive: true, force: true });
+
+    const result = runCli(dir, "gc");
+    expect(result.status).toBe(0);
+    expect(result.stdout).toContain(`Abandoned: ${abandonName} (cwd-gone)`);
+    expect(result.stdout).toContain(`Respawned: ${respawnName}`);
+
+    // Track any respawn pid for cleanup.
+    try {
+      const pid = parseInt(fs.readFileSync(path.join(dir, `${respawnName}.pid`), "utf-8").trim(), 10);
+      if (Number.isFinite(pid)) bgPids.push(pid);
+    } catch {}
+  }, 25000);
+});


### PR DESCRIPTION
Fixes #47.

## Problem

`strategy=permanent` daemons are immortal by design — `pty gc` respawns them when they exit. But nothing reaps them when they're **abandoned** (worktree deleted, no attach for weeks). schickling observed thousands of orphaned daemon nodes accumulating on long-lived hosts, and #47 asked for a conservative opt-in reaper.

## Fix

Adds a new **`pty gc` step 1.5** between orphan-kill (step 1) and permanent-respawn (step 2). Reaps live permanent sessions detected as abandoned. Two shapes today, both proposed on the issue:

### cwd-gone (on-by-default)

The session's recorded `cwd` no longer resolves on disk (`fs.statSync` throws `ENOENT`). Strong low-false-positive signal — if the worktree is gone, nobody's coming back to that session. Reap by default. Escape hatch: `strategy.abandon-if-cwd-gone=false` tag opts a session out.

### idle (opt-in)

The session's `lastAttachAt` is older than a configured threshold. Enabled via `pty gc --idle-days N` (global) OR a per-session `strategy.idle-days=N` tag (per-session wins). Sessions with **no `lastAttachAt`** — never attached — are excluded, since a session just spawned but not yet used isn't "idle."

### Precedence

`cwd-gone` wins over `idle` when both conditions hold. The event carries `reason: "cwd-gone"` and `idleDays` is omitted.

### Reap mechanics

If the daemon is alive: SIGTERM, wait up to 1s. Then append a `session_abandoned` event **before** `cleanupAll` (so watchers still see the reap even though the events file gets unlinked next). Then `cleanupAll`. Same shape as the existing orphan-kill in step 1.

## Public surface changes

- `SessionMetadata` gains `lastAttachAt?: string` (ISO 8601). Written by the daemon on every non-readonly `ATTACH`. Best-effort — a torn read during a concurrent `pty tag` / `pty rename` mutation doesn't crash the daemon.
- `EventType.SESSION_ABANDONED` = `"session_abandoned"` + `SessionAbandonedEvent { reason: "cwd-gone" | "idle"; idleDays? }`.
- `GcResult` gains `abandoned: { name; reason; idleDays? }[]`.
- CLI: `pty gc --idle-days N` (positive integer required; 0/negative rejected). New output row `Abandoned: <name> (<reason>)`; dry-run mirror `Would abandon:`. Summary line adds "N abandoned" when non-empty.
- Tags: `strategy.abandon-if-cwd-gone=false` (opt-out), `strategy.idle-days=<N>` (per-session opt-in).

## Docs

`docs/disk-layout.md` updated (new metadata field, new event, new tags). CHANGELOG entry under Unreleased.

## Tests

11 new in `tests/gc-abandoned.test.ts`, all passing:

- **cwd-gone**: reap on live permanent + deleted cwd; non-permanent unaffected; opt-out tag honored; `--dry-run` previews without touching.
- **idle-days**: reap on old `lastAttachAt`; under-threshold preserved; never-attached preserved; per-session tag opt-in without CLI flag; flag validation rejects 0 and negative.
- **precedence**: cwd-gone wins over idle when both fire.
- **compositional**: same gc pass still respawns a normal exited permanent session alongside abandoned-reap.

`tests/gc.test.ts`, `tests/gc-permanent.test.ts`, `tests/gc-parent-child.test.ts`, `tests/events.test.ts`, `tests/integration.test.ts`, `tests/disk-layout-docs.test.ts` — 103/103 green with this change.

## Sequencing

Second of three PRs driving the incoming schickling OSS issues per brief-021. First was #49 (alt-screen SCREEN replay fix). Next is #40 (`pty run --permanent` + `--cleanup-on-clean-exit`) — depends on the tag-check pattern this PR exercises. #48 (schickling's `process.title` PR) waiting on their rebase against post-#44 main.

Ready for cos to walk + call the merge.