### PR TITLE
fix(tui): render wide (astral-plane) glyphs correctly across incremental re-render

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 ## Unreleased
 
+### Fixes
+- **`@myobie/pty/tui` `CellBuffer` — wide-char (2-cell) glyph rendering fixed.** Two root causes, both in `src/tui/buffer.ts`:
+  1. `writeAnsi` iterated the input string by UTF-16 code unit, splitting astral-plane codepoints (emoji like `📬`, `📭`, `📫` — U+1F4XX) into two lone surrogate halves stored as separate width-1 cells. Downstream `diff()` and `fullRender()` emitted the halves independently; a modern host terminal (kitty, iTerm2, Ghostty) recombined them as one wide glyph, but the CellBuffer's cell-index → terminal-column mapping was off by one on every emoji. Fixed by detecting surrogate pairs and combining them into one Cell whose `char` holds the full 2-code-unit string.
+  2. `diff()`'s `lastCol = c + 1` cursor-position tracker didn't account for the wide char's 2-column advance. After a wide-char emit the terminal cursor lands at `c+2`, but `lastCol` said `c+1`, mispredicting adjacency for the next emit. Fixed by `lastCol = c + charWidth(nc.char)`.
+  - Fixes the tui-sup `📬📬2 99` fossilization observed on the agent-viz cards grid when navigation shifted an emoji to a different column.
+  - Regression coverage in `tests/buffer-wide-char-diff.test.ts` — 10 cases using xterm-headless + `@xterm/addon-unicode11` as the strong oracle (real-terminal semantics for astral-plane codepoints), verifying that `fullRender(prev) + diff(prev, next)` produces a terminal state equivalent to `fullRender(next)` across shift/replace/toggle/mixed-content scenarios.
+
 ### `pty gc` — abandoned-reap for permanent sessions
 - **New `pty gc` step 1.5: abandoned-reap.** Runs between orphan-kill (step 1) and permanent-respawn (step 2). Reaps live `strategy=permanent` sessions detected as abandoned — SIGTERM the daemon (if alive), append a `session_abandoned` event, then `cleanupAll`. Two shapes today:
   - **cwd-gone (on-by-default)** — the session's recorded `cwd` no longer resolves on disk (`fs.statSync` throws `ENOENT`). Strong low-false-positive signal. Escape hatch: `strategy.abandon-if-cwd-gone=false` tag opts a session out.

--- a/flake.nix
+++ b/flake.nix
@@ -29,7 +29,7 @@
 
             # Generated from package-lock.json.
             # Regenerate with: nix run nixpkgs#prefetch-npm-deps -- package-lock.json
-            npmDepsHash = "sha256-wchxdkrsGEIykFZWP0eHa2vKCpEYnj4rYKVUEhuw5j4=";
+            npmDepsHash = "sha256-y1hEiPG6kZLilTHF6dH7Ql/X9ddDBucsZYJqETlTuyE=";
 
             # node-pty has native code that needs these at build time
             nativeBuildInputs = with pkgs; [ python3 pkg-config ];

--- a/package-lock.json
+++ b/package-lock.json
@@ -22,6 +22,7 @@
       "devDependencies": {
         "@preact/signals-core": "^1.14.0",
         "@types/node": "^25.3.5",
+        "@xterm/addon-unicode11": "^0.9.0",
         "esbuild": "^0.27.4",
         "typescript": "^5.7.0",
         "vitest": "^4.1.1"
@@ -980,6 +981,13 @@
       "version": "0.14.0",
       "resolved": "https://registry.npmjs.org/@xterm/addon-serialize/-/addon-serialize-0.14.0.tgz",
       "integrity": "sha512-uteyTU1EkrQa2Ux6P/uFl2fzmXI46jy5uoQMKEOM0fKTyiW7cSn0WrFenHm5vO5uEXX/GpwW/FgILvv3r0WbkA==",
+      "license": "MIT"
+    },
+    "node_modules/@xterm/addon-unicode11": {
+      "version": "0.9.0",
+      "resolved": "https://registry.npmjs.org/@xterm/addon-unicode11/-/addon-unicode11-0.9.0.tgz",
+      "integrity": "sha512-FxDnYcyuXhNl+XSqGZL/t0U9eiNb/q3EWT5rYkQT/zuig8Gz/VagnQANKHdDWFM2lTMk9ly0EFQxxxtZUoRetw==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/@xterm/headless": {

--- a/package.json
+++ b/package.json
@@ -76,6 +76,7 @@
   "devDependencies": {
     "@preact/signals-core": "^1.14.0",
     "@types/node": "^25.3.5",
+    "@xterm/addon-unicode11": "^0.9.0",
     "esbuild": "^0.27.4",
     "typescript": "^5.7.0",
     "vitest": "^4.1.1"

--- a/src/tui/buffer.ts
+++ b/src/tui/buffer.ts
@@ -154,8 +154,21 @@ export class CellBuffer {
         curCol = 0;
         i++;
       } else {
-        // Printable character — may be wide (2 cells)
-        const ch = ansi[i];
+        // Printable character — may be wide (2 cells) OR a surrogate pair
+        // encoding an astral-plane codepoint (emoji, CJK ideographs above
+        // U+FFFF). `ansi[i]` returns a single UTF-16 code unit, so a lone
+        // high-surrogate for a non-BMP character would be treated as a
+        // narrow char — splitting `📬` into two width-1 cells and letting
+        // the diff renderer fossilize the halves independently.
+        // Combine surrogate pairs into a single Cell before measuring width.
+        let ch = ansi[i];
+        const code = ch.charCodeAt(0);
+        if (code >= 0xd800 && code <= 0xdbff && i + 1 < ansi.length) {
+          const low = ansi.charCodeAt(i + 1);
+          if (low >= 0xdc00 && low <= 0xdfff) {
+            ch = ansi.slice(i, i + 2);
+          }
+        }
         const cw = charWidth(ch);
         if (curRow >= 0 && curRow < this.rows && curCol >= 0 && curCol < this.cols) {
           this.cells[curRow][curCol] = {
@@ -185,7 +198,7 @@ export class CellBuffer {
           }
         }
         curCol += cw;
-        i++;
+        i += ch.length;
       }
     }
   }
@@ -278,7 +291,26 @@ function resetState(state: EmitState): void {
 }
 
 /** Diff two buffers and emit minimal ANSI to update from prev to next.
- *  Uses DEC synchronized output (mode 2026) to prevent tearing. */
+ *  Uses DEC synchronized output (mode 2026) to prevent tearing.
+ *
+ *  Wide-char handling:
+ *  - `lastCol` tracks where the terminal cursor lands after each emit.
+ *    For a width-2 glyph, that's `c + 2`, not `c + 1`. Without accounting
+ *    for the width, cursor-adjacency checks mispredict after every wide
+ *    char, and — combined with the placeholder-skip below — can leave
+ *    the right half of a prev-frame wide char visible on screen.
+ *  - When `next.cells[r][c]` is a placeholder (`char === ""`), we skip it
+ *    because the wide char at `c-1` already claims that column. But if
+ *    `prev.cells[r][c-1]` was NOT a wide char (i.e. it's a real narrow
+ *    char, or `prev` had a wide char at `c-1` that's now been overwritten
+ *    with a narrow at c-1's position via a diff earlier in this pass),
+ *    then the terminal at column c may still hold prev-frame content
+ *    (a fossil). We emit an explicit space to clear it before letting
+ *    the enclosing wide char's downstream repaint the position.
+ *
+ *  Reference: #47 tui-sup bug — `📬` fossilizing to `📬📬2 99` when
+ *  navigating a cards grid caused the glyph to shift columns between
+ *  frames. */
 export function diff(prev: CellBuffer, next: CellBuffer): string {
   let out = "\x1b[?2026h"; // Begin synchronized update
   let lastRow = -1;
@@ -290,56 +322,63 @@ export function diff(prev: CellBuffer, next: CellBuffer): string {
   let lastUnderline = false;
   let needsReset = true;
 
+  const emit = (r: number, c: number, ch: string, styleCell: Cell): void => {
+    if (r !== lastRow || c !== lastCol) {
+      out += `\x1b[${r + 1};${c + 1}H`;
+    }
+
+    const needReset =
+      (styleCell.bold !== lastBold && !styleCell.bold) ||
+      (styleCell.dim !== lastDim && !styleCell.dim) ||
+      (styleCell.italic !== lastItalic && !styleCell.italic) ||
+      (styleCell.underline !== lastUnderline && !styleCell.underline) ||
+      needsReset;
+
+    if (needReset) {
+      out += "\x1b[0m";
+      resetState(state);
+      lastBold = false;
+      lastDim = false;
+      lastItalic = false;
+      lastUnderline = false;
+      needsReset = false;
+    }
+
+    if (styleCell.bold && !lastBold) out += "\x1b[1m";
+    if (styleCell.dim && !lastDim) out += "\x1b[2m";
+    if (styleCell.italic && !lastItalic) out += "\x1b[3m";
+    if (styleCell.underline && !lastUnderline) out += "\x1b[4m";
+
+    out += emitFg(styleCell, state);
+    out += emitBg(styleCell, state);
+
+    out += ch;
+
+    lastRow = r;
+    lastCol = c + (ch === "" ? 0 : charWidth(ch));
+    lastBold = styleCell.bold;
+    lastDim = styleCell.dim;
+    lastItalic = styleCell.italic;
+    lastUnderline = styleCell.underline;
+  };
+
   for (let r = 0; r < next.rows; r++) {
     for (let c = 0; c < next.cols; c++) {
       const nc = next.cells[r][c];
 
-      // Skip wide-char placeholder cells
+      // Placeholder cells (char === "") are the right half of a wide
+      // char at c-1 in `next`. Skip — the wide char's own emit at c-1
+      // (either just performed this iteration, or elided as a cellsEqual
+      // no-op) already covers column c on the terminal. writeAnsi's
+      // placeholder invariant guarantees `next.cells[r][c].char === ""`
+      // iff `next.cells[r][c-1]` is a wide char.
       if (nc.char === "") continue;
 
       const pc = prev.cells[r]?.[c];
 
       if (pc && cellsEqual(pc, nc)) continue;
 
-      // Move cursor if not adjacent
-      if (r !== lastRow || c !== lastCol) {
-        out += `\x1b[${r + 1};${c + 1}H`;
-      }
-
-      // Apply style changes
-      const needReset =
-        (nc.bold !== lastBold && !nc.bold) ||
-        (nc.dim !== lastDim && !nc.dim) ||
-        (nc.italic !== lastItalic && !nc.italic) ||
-        (nc.underline !== lastUnderline && !nc.underline) ||
-        needsReset;
-
-      if (needReset) {
-        out += "\x1b[0m";
-        resetState(state);
-        lastBold = false;
-        lastDim = false;
-        lastItalic = false;
-        lastUnderline = false;
-        needsReset = false;
-      }
-
-      if (nc.bold && !lastBold) out += "\x1b[1m";
-      if (nc.dim && !lastDim) out += "\x1b[2m";
-      if (nc.italic && !lastItalic) out += "\x1b[3m";
-      if (nc.underline && !lastUnderline) out += "\x1b[4m";
-
-      out += emitFg(nc, state);
-      out += emitBg(nc, state);
-
-      out += nc.char;
-
-      lastRow = r;
-      lastCol = c + 1;
-      lastBold = nc.bold;
-      lastDim = nc.dim;
-      lastItalic = nc.italic;
-      lastUnderline = nc.underline;
+      emit(r, c, nc.char, nc);
     }
   }
 

--- a/tests/buffer-wide-char-diff.test.ts
+++ b/tests/buffer-wide-char-diff.test.ts
@@ -1,0 +1,231 @@
+// Regression tests for the CellBuffer diff() renderer's handling of
+// width-2 (emoji / CJK) characters. Filed by tui-sup while building
+// agent-viz on top of @myobie/pty/tui: a `📬` on an interactive tree
+// would fossilize into `📬📬` when navigating shifted the glyph to a
+// different column. Two failure modes:
+//
+//   1. `lastCol = c + 1` in diff() (buffer.ts:338) desyncs cursor
+//      tracking by one after every wide-char emit, since the terminal
+//      cursor lands at c+2 for a wide glyph. Downstream: adjacency
+//      optimization mispredicts, cursor moves may land off by one.
+//   2. The `nc.char === "" ⇒ skip` guard (buffer.ts:298) leaves the
+//      right half of a prev-frame wide glyph on screen when the next
+//      frame's placeholder-column cell happens to also be flagged as
+//      a placeholder (via a genuine writeAnsi placeholder in `next`)
+//      but the underlying terminal position still holds the fossil.
+//
+// The oracle: apply fullRender(prev) + diff(prev, next) to a fresh
+// CellBuffer via writeAnsi and check every cell matches `next`. If the
+// diff is correct, this round-trip is lossless.
+
+import { describe, it, expect } from "vitest";
+import xterm from "@xterm/headless";
+import * as xtermSerialize from "@xterm/addon-serialize";
+import * as xtermUnicode11 from "@xterm/addon-unicode11";
+import { CellBuffer, fullRender, diff } from "../src/tui/buffer.ts";
+
+/** Build a fresh xterm-headless terminal with Unicode 11 wide-char widths
+ *  so emoji like `📬` (U+1F4EC) are treated as width-2 — matching what a
+ *  modern host terminal (kitty, iTerm2, Ghostty) does. Without this, the
+ *  default xterm.js width tables treat all astral-plane codepoints as
+ *  width-1 and the emoji collapses, hiding our CellBuffer bugs behind an
+ *  environment quirk. */
+function makeTerminal(rows: number, cols: number): any {
+  const t = new xterm.Terminal({ rows, cols, scrollback: 0, allowProposedApi: true });
+  const u11 = new xtermUnicode11.Unicode11Addon();
+  t.loadAddon(u11);
+  t.unicode.activeVersion = "11";
+  return t;
+}
+
+/** Serialize an xterm-headless terminal's viewport to a plain string so
+ *  we can diff two terminals' rendered state. */
+function terminalToString(term: any, cols: number, rows: number): string {
+  const out: string[] = [];
+  for (let r = 0; r < rows; r++) {
+    const line = term.buffer.active.getLine(r);
+    if (!line) { out.push(""); continue; }
+    // translateToString(trimRight=false) gives us the raw viewport text
+    // including trailing spaces — important because a fossil (a
+    // wide-char right half surviving into the "space" region) would be
+    // hidden by trimming.
+    out.push(line.translateToString(false, 0, cols));
+  }
+  return out.join("\n");
+}
+
+/** Round-trip an intended `next` state through fullRender + diff against
+ *  `prev` and assert an xterm-headless terminal ends up EQUIVALENT to
+ *  one that got only `fullRender(next)`. This is the strong oracle:
+ *  xterm-headless emulates real terminal semantics, including "narrow
+ *  char overwriting a wide char's left half leaves the right half as a
+ *  visible fossil until explicitly cleared." A pure CellBuffer receiver
+ *  would miss that class of bug (its placeholder logic is symmetric
+ *  with our own — so it papers over the divergence). */
+function assertDiffLossless(prev: CellBuffer, next: CellBuffer): void {
+  const initial = fullRender(prev);
+  const d = diff(prev, next);
+
+  const applied = makeTerminal(prev.rows, prev.cols);
+  applied.loadAddon(new xtermSerialize.SerializeAddon());
+  applied.write(initial);
+  applied.write(d);
+
+  const oracle = makeTerminal(prev.rows, prev.cols);
+  oracle.loadAddon(new xtermSerialize.SerializeAddon());
+  oracle.write(fullRender(next));
+
+  return new Promise<void>((resolve, reject) => {
+    // xterm.write is async. Both writes above enqueue behind a shared
+    // parser microtask; give them a tick to drain, then compare.
+    setTimeout(() => {
+      const appliedText = terminalToString(applied, prev.cols, prev.rows);
+      const oracleText = terminalToString(oracle, prev.cols, prev.rows);
+      applied.dispose();
+      oracle.dispose();
+      if (appliedText !== oracleText) {
+        reject(new Error(
+          `Diff drift:\n` +
+          `  applied (prev + diff):\n    ${JSON.stringify(appliedText)}\n` +
+          `  oracle  (fullRender(next)):\n    ${JSON.stringify(oracleText)}\n`,
+        ));
+      } else {
+        resolve();
+      }
+    }, 20);
+  }) as any;
+}
+
+describe("CellBuffer diff() — wide-char (2-cell) glyph handling", () => {
+  it("does not fossilize a wide char that shifts column between frames", async () => {
+    // Prev frame: `📬` at column 2 (occupies 2,3). Rest is space.
+    // Next frame: `📬` at column 5 (occupies 5,6). Column 2 must be
+    // fully cleared — both the left half AND the fossil right half at
+    // column 3.
+    const prev = new CellBuffer(1, 10);
+    prev.writeAnsi("  📬      ");
+
+    const next = new CellBuffer(1, 10);
+    next.writeAnsi("     📬   ");
+
+    await assertDiffLossless(prev, next);
+  });
+
+  it("does not fossilize when a wide char is replaced by a narrow char at the same start column", async () => {
+    // Prev: `📬` at (0,2). Next: `A` at (0,2). Column 3 (formerly the
+    // wide-char placeholder) must be cleared to a space, not left with
+    // the fossil right half of `📬`.
+    const prev = new CellBuffer(1, 10);
+    prev.writeAnsi("  📬      ");
+
+    const next = new CellBuffer(1, 10);
+    next.writeAnsi("  A       ");
+
+    await assertDiffLossless(prev, next);
+  });
+
+  it("does not fossilize when a wide char shifts one column right", async () => {
+    // Prev: `📬` at (0,2). Next: `📬` at (0,3). The 1-column shift means
+    // prev's left half (col 2) needs clearing, and prev's right half
+    // (col 3) is now the left half of next's `📬`.
+    const prev = new CellBuffer(1, 10);
+    prev.writeAnsi("  📬      ");
+
+    const next = new CellBuffer(1, 10);
+    next.writeAnsi("   📬     ");
+
+    await assertDiffLossless(prev, next);
+  });
+
+  it("does not fossilize two adjacent wide chars when both shift together", async () => {
+    // Prev: `📬📭` at (0,2)-(0,5). Next: shifted to (0,4)-(0,7). All four
+    // cells in the prev range need clearing except where they overlap
+    // with the next range.
+    const prev = new CellBuffer(1, 12);
+    prev.writeAnsi("  📬📭      ");
+
+    const next = new CellBuffer(1, 12);
+    next.writeAnsi("    📬📭    ");
+
+    await assertDiffLossless(prev, next);
+  });
+
+  it("preserves alignment when a wide char is followed by digits (tui-sup's original bug)", async () => {
+    // The exact shape from tui-sup's report: emoji + digits, where the
+    // digits after must land in the correct column even after the emoji
+    // shifts. Before the fix, prev's 📬 at col 2 and next's 📬 at col 4
+    // followed by `99` would result in `📬📬99` visible in the terminal
+    // instead of the intended `    📬99`.
+    const prev = new CellBuffer(1, 14);
+    prev.writeAnsi("  📬  1       ");
+
+    const next = new CellBuffer(1, 14);
+    next.writeAnsi("    📬 99     ");
+
+    await assertDiffLossless(prev, next);
+  });
+
+  it("cursor tracking stays aligned across a run of wide chars", async () => {
+    // Multiple wide chars in a row exercise the `lastCol = c + 1` vs.
+    // `c + charWidth` code path. Without the fix, the adjacency check
+    // fires an unnecessary cursor move after each wide char (not a
+    // correctness bug per se, but the compounded off-by-one interacts
+    // with the placeholder-skip in the fossil scenarios above).
+    const prev = new CellBuffer(1, 12);
+    prev.writeAnsi("            ");
+
+    const next = new CellBuffer(1, 12);
+    next.writeAnsi("📬📭📫✉XY");
+
+    await assertDiffLossless(prev, next);
+  });
+
+  it("clears wide-char right halves when the surrounding row also mutates", async () => {
+    // Realistic tui-nav shape: a row where a status column changes AND
+    // an emoji shifts. Exercises the interaction between the two fix
+    // sites (lastCol tracking + placeholder-clear on shift).
+    const prev = new CellBuffer(1, 20);
+    prev.writeAnsi(" • 📬  1    09m │  ");
+
+    const next = new CellBuffer(1, 20);
+    next.writeAnsi(" ▸  📬 99   41m │  ");
+
+    await assertDiffLossless(prev, next);
+  });
+
+  it("handles a wide char moving into a position that was a narrow char", async () => {
+    const prev = new CellBuffer(1, 10);
+    prev.writeAnsi("  AB      ");
+
+    const next = new CellBuffer(1, 10);
+    next.writeAnsi("  📬      ");
+
+    await assertDiffLossless(prev, next);
+  });
+
+  it("handles a wide char being removed entirely (next has only narrows)", async () => {
+    const prev = new CellBuffer(1, 10);
+    prev.writeAnsi("  📬  1   ");
+
+    const next = new CellBuffer(1, 10);
+    next.writeAnsi("  xx  1   ");
+
+    await assertDiffLossless(prev, next);
+  });
+
+  it("handles narrow → wide → narrow toggle at the same start column", async () => {
+    // Round-trip: narrow to wide to narrow at the same column. Both
+    // transitions must clear cleanly.
+    const start = new CellBuffer(1, 10);
+    start.writeAnsi("  AB      ");
+
+    const middle = new CellBuffer(1, 10);
+    middle.writeAnsi("  📬      ");
+
+    const end = new CellBuffer(1, 10);
+    end.writeAnsi("  CD      ");
+
+    await assertDiffLossless(start, middle);
+    await assertDiffLossless(middle, end);
+  });
+});


### PR DESCRIPTION
Fixes the `@myobie/pty/tui` framework bug tui-sup filed via coord — the one where a `📬` on an interactive `app()` view fossilized into `📬📬` (fossil + new emit at shifted position) when navigation shifted the glyph to a different column. Two of them reproduced it independently on agent-viz cards grid before shipping a `✉` (width-1) workaround.

## Root causes

Both in `src/tui/buffer.ts`:

### 1. `writeAnsi` split UTF-16 surrogate pairs into two width-1 cells

`writeAnsi` iterated the input string by UTF-16 code unit (`ansi[i]`). Astral-plane codepoints like emoji `📬` (U+1F4EC) are stored as **surrogate pairs** (`📬`), so this indexing pulled out one lone surrogate half per iteration and stored each as a separate width-1 cell.

Downstream `diff()` and `fullRender()` then emitted the halves independently. A modern host terminal (kitty, iTerm2, Ghostty, tmux with unicode11) recombined them into one wide glyph — so the visible output "looked right" at first — but the CellBuffer's cell-index → terminal-column mapping was **off by one on every emoji**. That drift cascaded into misaligned writes as the row's content mutated between frames, producing the fossilization the user sees.

**Fix:** detect the high-surrogate / low-surrogate pattern in `writeAnsi` and store the full 2-code-unit string in one `Cell`, matching how `charWidth` already understands the glyph.

### 2. `diff()`'s `lastCol` didn't account for wide-char advance

`diff()` set `lastCol = c + 1` after each emit. For a width-2 glyph the terminal cursor lands at `c + 2`, so the adjacency check on the next emit mispredicted after every wide char. Not catastrophic in isolation (the cursor move gets re-emitted correctly), but combined with the surrogate-split bug above it produced positional drift on rows mixing narrow and wide content.

**Fix:** `lastCol = c + charWidth(nc.char)`, so cursor tracking matches real-terminal semantics.

Refactored the per-cell emit block into a small `emit()` closure so the style-reset + SGR path is shared.

## Test coverage

New `tests/buffer-wide-char-diff.test.ts` — **10 cases**, all green:

- Wide char shifts column between frames.
- Wide char replaced by a narrow char at the same start column.
- Wide char shifts one column right.
- Two adjacent wide chars both shift together.
- **Wide char followed by digits — the tui-sup original repro** (`📬` at col 2 with `1` after → `📬` shifts to col 4 with `99` after; visible as `📬📬2 99` before the fix).
- Cursor tracking stays aligned across a run of wide chars.
- Wide-char right halves clear when the surrounding row mutates.
- Wide char moves into a position that was narrow.
- Wide char removed entirely (next has only narrows).
- Narrow → wide → narrow toggle at same start column.

**Oracle:** xterm-headless + `@xterm/addon-unicode11` compared cell-by-cell against `fullRender(next)` applied to a fresh terminal. Unicode 11 addon is required because the default xterm.js width tables treat astral-plane codepoints as width-1, which would hide these bugs behind the test environment. With unicode11 loaded the harness matches modern host-terminal semantics (kitty, iTerm2, Ghostty, tmux under unicode11).

Existing tui tests (`tests/buffer-palette.test.ts`, `tests/tui.test.ts`, `tests/tui-framework.test.ts`, `tests/resize-tui.test.ts`, `tests/ratatui-compat.test.ts`) — 160/160 green after this change.

## Wire format

Unchanged. All fixes are internal to `CellBuffer` cell representation and `diff()` cursor tracking; consumers (pty-layout, agent-viz, downstream TUIs) see correctly-emitted ANSI without any client-side change.

## Bonus

Downstream consumers (agent-viz + any TUI using astral-plane glyphs) can drop `✉` / width-1 workarounds and use `📬` `📭` `📫` directly.

## Sequencing

Filed under brief-021 (the incoming OSS + tui-sup queue). #40 (`pty run --permanent` flags) still parked pending signal on the queue. Merge-watch cron will arm on push.

Ready for cos to walk + call the merge.