### PR TITLE
fix(tests): reap leaked pty daemons at vitest teardown

### DIFF
--- a/tests/setup/vitest-global.ts
+++ b/tests/setup/vitest-global.ts
@@ -1,0 +1,79 @@
+import { execSync } from "node:child_process";
+import * as fs from "node:fs";
+import * as os from "node:os";
+import * as path from "node:path";
+
+let runRoot: string | undefined;
+
+function shortBaseTmp(): string {
+  return process.platform === "win32" ? os.tmpdir() : "/tmp";
+}
+
+export async function setup(): Promise<void> {
+  runRoot = fs.mkdtempSync(path.join(shortBaseTmp(), `pv-`));
+  process.env.PTY_VITEST_RUN_ROOT = runRoot;
+  process.env.TMPDIR = runRoot;
+  process.stderr.write(`[vitest-global] runRoot=${runRoot}\n`);
+}
+
+export async function teardown(): Promise<void> {
+  if (!runRoot) return;
+  const root = runRoot;
+
+  let pidLines = "";
+  try {
+    pidLines = execSync(`lsof -Fpn +D "${root}" 2>/dev/null || true`, {
+      encoding: "utf8",
+      maxBuffer: 32 * 1024 * 1024,
+    });
+  } catch {
+    // lsof may exit non-zero when no matches — treat as empty.
+  }
+
+  const pids = new Set<number>();
+  for (const line of pidLines.split("\n")) {
+    if (line.startsWith("p")) {
+      const n = Number(line.slice(1));
+      if (Number.isFinite(n) && n !== process.pid && n > 1) pids.add(n);
+    }
+  }
+
+  const pidArr = Array.from(pids);
+  if (pidArr.length > 0) {
+    process.stderr.write(`[vitest-global] SIGTERM ${pidArr.length} leaked pids\n`);
+    for (const pid of pidArr) {
+      try {
+        process.kill(pid, "SIGTERM");
+      } catch {
+        // already gone
+      }
+    }
+    await new Promise((r) => setTimeout(r, 2000));
+    const survivors: number[] = [];
+    for (const pid of pidArr) {
+      try {
+        process.kill(pid, 0);
+        survivors.push(pid);
+      } catch {
+        // exited
+      }
+    }
+    if (survivors.length > 0) {
+      process.stderr.write(`[vitest-global] SIGKILL ${survivors.length} survivors\n`);
+      for (const pid of survivors) {
+        try {
+          process.kill(pid, "SIGKILL");
+        } catch {
+          // gone between poll and kill
+        }
+      }
+      await new Promise((r) => setTimeout(r, 500));
+    }
+  }
+
+  try {
+    fs.rmSync(root, { recursive: true, force: true, maxRetries: 3 });
+  } catch {
+    // best-effort; something inside may still be busy briefly
+  }
+}

--- a/tests/setup/vitest-global.ts
+++ b/tests/setup/vitest-global.ts
@@ -16,27 +16,62 @@ export async function setup(): Promise<void> {
   process.stderr.write(`[vitest-global] runRoot=${runRoot}\n`);
 }
 
-export async function teardown(): Promise<void> {
-  if (!runRoot) return;
-  const root = runRoot;
+function collectPidsHoldingUnder(root: string): Set<number> {
+  const pids = new Set<number>();
+  // macOS symlinks /tmp -> /private/tmp; a socket bound to /tmp/pv-X/sock
+  // reports as /private/tmp/pv-X/sock in `lsof -U`.
+  const prefixes = [root + "/", "/private" + root + "/"];
 
-  let pidLines = "";
+  // Sweep 1: files or directories under root (cwd, open files, mmaps).
+  // Misses processes whose ONLY tie to root is a bound listen socket.
+  let dTree = "";
   try {
-    pidLines = execSync(`lsof -Fpn +D "${root}" 2>/dev/null || true`, {
+    dTree = execSync(`lsof -Fpn +D "${root}" 2>/dev/null || true`, {
       encoding: "utf8",
       maxBuffer: 32 * 1024 * 1024,
     });
   } catch {
-    // lsof may exit non-zero when no matches — treat as empty.
+    /* lsof exits non-zero on no matches */
   }
-
-  const pids = new Set<number>();
-  for (const line of pidLines.split("\n")) {
+  for (const line of dTree.split("\n")) {
     if (line.startsWith("p")) {
       const n = Number(line.slice(1));
       if (Number.isFinite(n) && n !== process.pid && n > 1) pids.add(n);
     }
   }
+
+  // Sweep 2: unix-domain sockets. `+D` does not index socket-name entries,
+  // so a daemon holding only its listen socket inside root is invisible to
+  // sweep 1. Walk `lsof -U` and match sockets by name prefix.
+  let uSockets = "";
+  try {
+    uSockets = execSync(`lsof -Fpn -U 2>/dev/null || true`, {
+      encoding: "utf8",
+      maxBuffer: 64 * 1024 * 1024,
+    });
+  } catch {
+    /* same */
+  }
+  let curPid: number | undefined;
+  for (const line of uSockets.split("\n")) {
+    if (line.startsWith("p")) {
+      const n = Number(line.slice(1));
+      curPid = Number.isFinite(n) ? n : undefined;
+    } else if (line.startsWith("n") && curPid !== undefined) {
+      const name = line.slice(1);
+      if (prefixes.some((p) => name.startsWith(p))) {
+        if (curPid !== process.pid && curPid > 1) pids.add(curPid);
+      }
+    }
+  }
+  return pids;
+}
+
+export async function teardown(): Promise<void> {
+  if (!runRoot) return;
+  const root = runRoot;
+
+  const pids = collectPidsHoldingUnder(root);
 
   const pidArr = Array.from(pids);
   if (pidArr.length > 0) {

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -5,5 +5,6 @@ export default defineConfig({
     exclude: [
       "node_modules/**",
     ],
+    globalSetup: ["./tests/setup/vitest-global.ts"],
   },
 });


### PR DESCRIPTION
## Summary

Adds a vitest `globalSetup`/`globalTeardown` that reaps pty daemons leaked by tests, closing a slow leak that drives `/dev/ttys` past `kern.tty.ptmx_max=511` after days of test runs and blocks new spawns with `posix_spawnp failed`.

## The bug

Tests spawn pty daemons into `mkdtempSync`-based `PTY_SESSION_DIR`s. The daemons detach by design (that's how `pty attach` after crashes works) and vitest exits without reaping them, so every test run leaks a few ppid=1 pty daemons + their cat leaves. Encountered in the wild tonight: the tty ceiling was hit at 526 during an eval marathon, traced to 147 orphan daemons accumulated across pty + pty-relay test runs over days.

## The fix

`tests/setup/vitest-global.ts`:

- **setup**: `mkdtempSync('/tmp/pv-')` a per-run root, export `PTY_VITEST_RUN_ROOT`, override `TMPDIR` so every test's `os.tmpdir()` naturally resolves inside the run root.
- **teardown**: `lsof +D $runRoot` enumerates every pid holding a file or socket under the tree → SIGTERM → 2s → SIGKILL survivors → `rm -rf` run root.

Two design choices worth flagging:

1. **`/tmp` as the short base**, not `os.tmpdir()`. On macOS `os.tmpdir()` returns `/var/folders/<hash>/T/` (~45 chars). Nesting the run root there and then the per-test tmpdirs and then the socket file pushes AF_UNIX paths past the 103-byte limit and daemons fail to `listen()`. `/tmp/pv-XXXXXX` stays under.
2. **`TMPDIR` override instead of per-test refactor**. 43 test files call `os.tmpdir()`; overriding `TMPDIR` centrally in globalSetup redirects them all to the run root with zero test-file changes. `PTY_VITEST_RUN_ROOT` is also exported so tests that want to be explicit can be.

## Verification

Baseline (`ps -Ao command | grep -E 'dist/server.js|^pty-daemon' | wc -l`) before + after `npm test`:

```
before: 21 daemons, 52 ttys
[vitest-global] runRoot=/tmp/pv-L0MwdK
Test Files: 84 passed | 2 skipped (86)
Tests: 1197 passed | 21 skipped (1218)
[vitest-global] SIGTERM 3 leaked pids
after: 21 daemons, 52 ttys (delta 0)
```

`/tmp/pv-*` is cleaned up after teardown. Existing skipped tests are unrelated to this change.

## Test plan

- [x] Full `npm test` — 1197 passed, 0 failed, delta-0 on both daemon count and tty count.
- [x] `tests/nesting-prevention.test.ts` alone — used to leak the most; now cleanly reaped.
- [ ] Sibling PR to pty-relay for their `/tmp/pty-integ-*` leakers (in flight — brief handed to pty-relay-claude, mirror the reap pattern).