### PR TITLE
fix(tui): route ssh:// peer attach through label + --session

### DIFF
--- a/src/tui/interactive.ts
+++ b/src/tui/interactive.ts
@@ -513,15 +513,24 @@ async function doRestart(session: SessionInfo): Promise<void> {
   doAttach(session.name);
 }
 
+/** Build the argv for attaching to a remote session. ssh:// peers have no
+ *  path-in-URL convention — pty-relay's connect looks them up by label +
+ *  a `--session <name>` flag. Token URLs still take the session name as
+ *  a path segment (parseToken handles that). Exported for unit testing. */
+export function buildAttachRemoteArgs(host: RelayHost, session: RemoteSession): string[] {
+  if (host.url.startsWith("ssh://")) {
+    return ["connect", host.label, "--session", session.name];
+  }
+  const url = host.url.replace(/#.*$/, "") + "/" + session.name +
+    (host.url.includes("#") ? "#" + host.url.split("#").slice(1).join("#") : "");
+  return ["connect", url];
+}
+
 function doAttachRemote(host: RelayHost, session: RemoteSession): void {
   if (!relayBin) return;
   pauseApp();
 
-  // Build the connect URL: base URL + /session-name
-  const url = host.url.replace(/#.*$/, "") + "/" + session.name +
-    (host.url.includes("#") ? "#" + host.url.split("#").slice(1).join("#") : "");
-
-  const result = spawnSync(relayBin, ["connect", url], {
+  const result = spawnSync(relayBin, buildAttachRemoteArgs(host, session), {
     stdio: "inherit",
   });
 

--- a/tests/filter.test.ts
+++ b/tests/filter.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from "vitest";
-import { buildFilteredGroups, buildSpawnRemoteArgs, type ListItem, type RelayHost } from "../src/tui/interactive.ts";
+import { buildAttachRemoteArgs, buildFilteredGroups, buildSpawnRemoteArgs, type ListItem, type RelayHost, type RemoteSession } from "../src/tui/interactive.ts";
 import type { SessionInfo } from "../src/sessions.ts";
 
 function makeSession(name: string, status: "running" | "exited" = "running", opts?: { command?: string; cwd?: string; tags?: Record<string, string> }): SessionInfo {
@@ -252,6 +252,37 @@ describe("buildSpawnRemoteArgs", () => {
   it("preserves = in values", () => {
     expect(buildSpawnRemoteArgs("u", "n", { note: "k=v" })).toEqual([
       "connect", "u", "--spawn", "n", "--tag", "note=k=v",
+    ]);
+  });
+});
+
+describe("buildAttachRemoteArgs", () => {
+  const sess = (name: string): RemoteSession => ({ name, status: "running" });
+  const host = (label: string, url: string): RelayHost => ({
+    label, url, sessions: [], spawn_enabled: true, error: null,
+  });
+
+  it("appends session name to token URL path (no fragment)", () => {
+    expect(buildAttachRemoteArgs(host("h", "https://x.example"), sess("s1"))).toEqual([
+      "connect", "https://x.example/s1",
+    ]);
+  });
+
+  it("appends session name before the URL fragment (with token hash)", () => {
+    expect(buildAttachRemoteArgs(host("h", "https://x.example#tok"), sess("s2"))).toEqual([
+      "connect", "https://x.example/s2#tok",
+    ]);
+  });
+
+  it("uses label + --session for ssh:// peers, ignoring URL-path convention", () => {
+    expect(buildAttachRemoteArgs(host("home", "ssh://me@home"), sess("chat"))).toEqual([
+      "connect", "home", "--session", "chat",
+    ]);
+  });
+
+  it("ssh peers with port keep label routing", () => {
+    expect(buildAttachRemoteArgs(host("box", "ssh://user@box:2222"), sess("s"))).toEqual([
+      "connect", "box", "--session", "s",
     ]);
   });
 });


### PR DESCRIPTION
## Summary

Interactive picker + attach-remote for `ssh://` peers exits 1 instead of connecting — Nathan hit this on a fresh machine where his `~/.config/pty-relay/peers` file has an ssh:// entry, `pty relay ls` works, but choosing one of that host's sessions in the `pty` picker fails.

## Root cause

`src/tui/interactive.ts:doAttachRemote` built `host.url + "/" + session.name` and invoked `pty-relay connect <that>`.

- For token URLs (`http://` / `https://`), the trailing `/session-name` is a path segment that pty-relay's `parseToken` picks up. Works.
- For `ssh://` peers there's no path convention. `pty-relay connect ssh://user@host/session-name` falls into pty-relay's label branch, `resolveHost` does `hosts.find(h => h.label === that)`, misses, and exits with `No known host`. Even if it resolved by URL match, the ssh branch reads the session name from `--session`/`--spawn`, not from the URL path.

## Fix

`buildAttachRemoteArgs(host, session)`:

- `ssh://`  → `["connect", host.label, "--session", session.name]` — matches pty-relay's ssh-peer contract.
- everything else → path-append as before.

Extracted alongside sibling `buildSpawnRemoteArgs` for unit testability.

## Belt-and-suspenders

A mirror fix in pty-relay is in flight (brief handed to pty-relay-claude): teach `connect(tokenUrlOrLabel)` to parse a session name from an `ssh://` URL's trailing path too, so `pty-relay connect ssh://user@host/session-name` from any caller (this TUI, a human at a terminal, another script) works uniformly. This PR closes the immediate user-facing bug; the pty-relay PR hardens the seam.

## Test plan

- [x] `tests/filter.test.ts` — 4 new cases for `buildAttachRemoteArgs`: token URL no-fragment, token URL with `#tok`, ssh peer, ssh peer with port. 25 passed (was 21).
- [x] Full suite: 1201 passed, 21 skipped, 0 failed; daemon count delta 0.
- [ ] Manual end-to-end on the other machine: pull main after merge, `pty`, pick an ssh-peer session, attach lands successfully.