### PR TITLE
fix(gc): fast-fail respawn cap on permanent sessions (#54)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,19 @@
 
 ## Unreleased
 
+### `pty gc` fast-fail respawn cap (fixes #54)
+
+- **New:** `pty gc` STEP-2 now detects a crash-looping permanent session and stops respawning it before it churns forever. A respawn whose leaf exits within `strategy.fast-fail-window` seconds (default 60) of the previous respawn counts as a fast fail; after `strategy.fast-fail-limit` consecutive fast fails (default 3) the session gets `strategy.status=flapping` written to its tags and a `session_flapping` event, and subsequent gc ticks silently skip it. This is the crash-loop-with-live-cwd case that the earlier `cwd-gone`/`idle` reap (#47, #50) didn't cover.
+- **New event `session_flapping`.** Payload `{ session, type: "session_flapping", ts, counter, limit, window }`. `counter` is the fast-fail streak at the moment of flip (>= `limit`); `window` is the resolved window in seconds. Documented in `docs/disk-layout.md`.
+- **New bookkeeping tags on permanent sessions.** Written by `pty gc` on every respawn: `strategy.last-respawn-at` (ISO timestamp), `strategy.consecutive-fast-fails` (running counter), `strategy.command-hash` (16-char SHA-256 prefix of the respawn command line — used to auto-reset the counter and clear a stale flapping mark when the operator edits the stored command). At the flip: `strategy.status=flapping` is added.
+- **Manual reset:** `pty tag <name> --rm strategy.status` (or `pty tag ... --rm strategy.consecutive-fast-fails --rm strategy.last-respawn-at` for a full clean-slate). The next gc tick retries.
+- **Auto-reset on command change:** the classifier compares the new command's fingerprint against `strategy.command-hash`. If they differ, the counter resets to zero and `strategy.status=flapping` clears — the operator has already reshaped the problem, no manual step needed.
+- **Per-session overrides** — `strategy.fast-fail-window=<sec>` and `strategy.fast-fail-limit=<int>` tags override the defaults for one session; higher precedence than the CLI globals.
+- **New CLI globals** — `pty gc --fast-fail-window=<sec>` and `pty gc --fast-fail-limit=<int>` mirror the per-session tags for anyone who wants to override the defaults for a whole gc run.
+- **`GcResult` gains two fields.** `flapped: { name, counter, limit, window }[]` — sessions the classifier flipped this tick. `flappingSkipped: string[]` — sessions the classifier silently skipped because they were already flagged. Both are surfaced in `cmdGc` output. Additive; existing consumers keep working.
+- **CLI output** — new lines: `Flapping: <name> (<N> fast-fails in <W>s, limit <L>)` on the flip tick and `Skipped (flapping): <name> — remove strategy.status tag to retry` on subsequent ticks. Summary bar adds `N flapping` / `N skipped-flapping` when non-empty. `--dry-run` mirrors with `Would flap: ...`.
+- Tests in `tests/gc-flapping.test.ts` (10 new) cover: dry-run previews, at-limit persistence + event emission, already-flapping silent skip, slow-fail counter reset, command-hash auto-reset (clears flapping mark), per-session and CLI-global window/limit overrides, and the first-respawn (no prior last-respawn-at) case.
+
 ### Per-namespace isolation — `PTY_ROOT` + `pty --root <path>`
 
 - **New canonical env var `PTY_ROOT`** for the state registry directory (default `~/.local/state/pty`). The pre-existing `PTY_SESSION_DIR` still works and continues to point at the same registry; when only the legacy name is set, `pty` emits a one-time deprecation notice to stderr per process. Precedence: `PTY_ROOT > PTY_SESSION_DIR > default`.

--- a/README.md
+++ b/README.md
@@ -266,6 +266,22 @@ tags = { strategy = "permanent" }
 
 Restart is stateless — every `pty gc` invocation re-derives intent from on-disk metadata. There's no in-memory restart counter, no `[failed]` state, no persisted bookkeeping. If a session's binary isn't reachable (volume not mounted, broken symlink), `pty gc` reports `Respawn failed:` and the next tick tries again.
 
+**Fast-fail cap** — a permanent session whose leaf exits within `strategy.fast-fail-window` seconds of its previous `pty gc` respawn counts as a fast fail. After `strategy.fast-fail-limit` consecutive fast fails, `pty gc` writes `strategy.status=flapping` on the session, emits a `session_flapping` event, and stops respawning it. Subsequent gc ticks print `Skipped (flapping): <name>` and take no action. Defaults: 60 s window, 3 consecutive fast fails.
+
+Reset a flagged session with one of:
+
+- `pty tag <name> --rm strategy.status` — clear the mark, `pty gc` retries on the next tick.
+- Edit the session's `pty.toml` command — the classifier notices the SHA-256 fingerprint change and auto-resets the counter and mark.
+
+Per-session overrides tune the cap without editing gc's globals:
+
+```sh
+pty tag myserver strategy.fast-fail-window=120  # allow 2min of runtime before "fast"
+pty tag myserver strategy.fast-fail-limit=5     # tolerate 5 fast fails before flapping
+```
+
+CLI globals mirror the per-session tags (`--fast-fail-window=N`, `--fast-fail-limit=N`); the per-session tag wins when both are set.
+
 ### Parent-child sessions
 
 Tag a session with `parent=<name>` and `pty gc` will SIGTERM it (and clean up its metadata) when the referenced parent's daemon is no longer alive — useful for sidecar workers that shouldn't outlive their primary:

--- a/docs/disk-layout.md
+++ b/docs/disk-layout.md
@@ -75,6 +75,7 @@ Envelope: `{ session: string; type: string; ts: string; ...payload }`. Event typ
 | `session_exec` | `previousCommand, command` |
 | `session_respawn` | — (`pty gc` respawned a `strategy=permanent` session) |
 | `session_abandoned` | `reason: "cwd-gone" \| "idle", idleDays?` — (`pty gc` reaped a live permanent session detected as abandoned) |
+| `session_flapping` | `counter, limit, window` — (`pty gc` flipped a permanent session to `strategy.status=flapping` after N consecutive fast-fail respawns; subsequent ticks skip it) |
 | `display_name_change` | `previous: string\|null, value: string\|null` |
 | `tags_change` | `previous, value` (full snapshots) |
 | `state.set` | `key, value` |

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -129,6 +129,8 @@ function usage(): void {
   pty tag-multi <selector> [ops...]        Read/write tags across multiple sessions (--all / --filter-tag k=v / <name>...)
   pty gc --print-launchd-plist [--interval=N]   Print a launchd plist that runs 'pty gc' every N seconds (default 30)
   pty gc [--dry-run] [--idle-days N]       Reconciliation pass; --idle-days N reaps permanent sessions with no attach in N days
+  pty gc --fast-fail-window=N              Fast-fail window (seconds) for the respawn cap (default 60; per-session tag wins)
+  pty gc --fast-fail-limit=N               Consecutive fast fails before a permanent session is flagged flapping (default 3)
   pty wrap <command>                       Auto-wrap a command in pty sessions
   pty unwrap <command>                     Remove a wrap
   pty wrap --list                          List wrapped commands
@@ -758,45 +760,41 @@ async function main(): Promise<void> {
       const printPlist = gcArgs.includes("--print-launchd-plist");
       let interval = 30;
       let idleDays: number | undefined;
+      let fastFailWindowSec: number | undefined;
+      let fastFailLimit: number | undefined;
+      const parsePositive = (flag: string, raw: string): number => {
+        const v = parseInt(raw, 10);
+        if (!Number.isFinite(v) || v <= 0) {
+          console.error(`pty gc: ${flag} expects a positive integer (got "${raw}")`);
+          process.exit(1);
+        }
+        return v;
+      };
       for (let i = 0; i < gcArgs.length; i++) {
         const a = gcArgs[i];
         if (a === "--interval" && i + 1 < gcArgs.length) {
-          const v = parseInt(gcArgs[i + 1], 10);
-          if (!Number.isFinite(v) || v <= 0) {
-            console.error(`pty gc: --interval expects a positive integer (got "${gcArgs[i + 1]}")`);
-            process.exit(1);
-          }
-          interval = v;
-          i++;
+          interval = parsePositive("--interval", gcArgs[++i]);
         } else if (a.startsWith("--interval=")) {
-          const v = parseInt(a.slice("--interval=".length), 10);
-          if (!Number.isFinite(v) || v <= 0) {
-            console.error(`pty gc: --interval expects a positive integer (got "${a.slice("--interval=".length)}")`);
-            process.exit(1);
-          }
-          interval = v;
+          interval = parsePositive("--interval", a.slice("--interval=".length));
         } else if (a === "--idle-days" && i + 1 < gcArgs.length) {
-          const v = parseInt(gcArgs[i + 1], 10);
-          if (!Number.isFinite(v) || v <= 0) {
-            console.error(`pty gc: --idle-days expects a positive integer (got "${gcArgs[i + 1]}")`);
-            process.exit(1);
-          }
-          idleDays = v;
-          i++;
+          idleDays = parsePositive("--idle-days", gcArgs[++i]);
         } else if (a.startsWith("--idle-days=")) {
-          const v = parseInt(a.slice("--idle-days=".length), 10);
-          if (!Number.isFinite(v) || v <= 0) {
-            console.error(`pty gc: --idle-days expects a positive integer (got "${a.slice("--idle-days=".length)}")`);
-            process.exit(1);
-          }
-          idleDays = v;
+          idleDays = parsePositive("--idle-days", a.slice("--idle-days=".length));
+        } else if (a === "--fast-fail-window" && i + 1 < gcArgs.length) {
+          fastFailWindowSec = parsePositive("--fast-fail-window", gcArgs[++i]);
+        } else if (a.startsWith("--fast-fail-window=")) {
+          fastFailWindowSec = parsePositive("--fast-fail-window", a.slice("--fast-fail-window=".length));
+        } else if (a === "--fast-fail-limit" && i + 1 < gcArgs.length) {
+          fastFailLimit = parsePositive("--fast-fail-limit", gcArgs[++i]);
+        } else if (a.startsWith("--fast-fail-limit=")) {
+          fastFailLimit = parsePositive("--fast-fail-limit", a.slice("--fast-fail-limit=".length));
         }
       }
       if (printPlist) {
         printLaunchdPlist(interval);
         break;
       }
-      await cmdGc(dryRun, idleDays);
+      await cmdGc(dryRun, idleDays, fastFailWindowSec, fastFailLimit);
       break;
     }
 
@@ -1930,13 +1928,19 @@ async function cmdRm(name: string): Promise<void> {
   console.log(`Session "${name}" removed.`);
 }
 
-async function cmdGc(dryRun: boolean, idleDays?: number): Promise<void> {
-  const result = await gc({ dryRun, idleDays });
+async function cmdGc(
+  dryRun: boolean,
+  idleDays?: number,
+  fastFailWindowSec?: number,
+  fastFailLimit?: number,
+): Promise<void> {
+  const result = await gc({ dryRun, idleDays, fastFailWindowSec, fastFailLimit });
   const prunedTags = await pruneOrphanLayoutTags({ dryRun });
 
   const killedVerb = dryRun ? "Would kill orphan child" : "Killed orphan child";
   const abandonVerb = dryRun ? "Would abandon" : "Abandoned";
   const respawnVerb = dryRun ? "Would respawn" : "Respawned";
+  const flapVerb = dryRun ? "Would flap" : "Flapping";
   const removeVerb = dryRun ? "Would remove" : "Removed";
   const prunedVerb = dryRun ? "Would prune" : "Pruned";
 
@@ -1956,6 +1960,16 @@ async function cmdGc(dryRun: boolean, idleDays?: number): Promise<void> {
   for (const f of result.respawnFailed) {
     console.log(`Respawn failed: ${f.name} — ${f.error}`);
   }
+  for (const fl of result.flapped) {
+    console.log(
+      `${flapVerb}: ${fl.name} (${fl.counter} fast-fails in ${fl.window}s, limit ${fl.limit})`,
+    );
+  }
+  for (const name of result.flappingSkipped) {
+    console.log(
+      `Skipped (flapping): ${name} — remove strategy.status tag to retry`,
+    );
+  }
   for (const name of result.removed) {
     console.log(`${removeVerb}: ${name}`);
   }
@@ -1971,6 +1985,8 @@ async function cmdGc(dryRun: boolean, idleDays?: number): Promise<void> {
     result.abandoned.length +
     result.respawned.length +
     result.respawnFailed.length +
+    result.flapped.length +
+    result.flappingSkipped.length +
     result.removed.length +
     totalTags;
 
@@ -1991,6 +2007,12 @@ async function cmdGc(dryRun: boolean, idleDays?: number): Promise<void> {
   }
   if (result.respawnFailed.length > 0) {
     parts.push(`${result.respawnFailed.length} respawn failure${result.respawnFailed.length === 1 ? "" : "s"}`);
+  }
+  if (result.flapped.length > 0) {
+    parts.push(`${result.flapped.length} flapping`);
+  }
+  if (result.flappingSkipped.length > 0) {
+    parts.push(`${result.flappingSkipped.length} skipped-flapping`);
   }
   if (result.removed.length > 0) {
     parts.push(`${result.removed.length} stale session${result.removed.length === 1 ? "" : "s"}`);

--- a/src/events.ts
+++ b/src/events.ts
@@ -16,6 +16,7 @@ export const EventType = {
   SESSION_EXEC: "session_exec",
   SESSION_RESPAWN: "session_respawn",
   SESSION_ABANDONED: "session_abandoned",
+  SESSION_FLAPPING: "session_flapping",
 } as const;
 
 export type EventType = (typeof EventType)[keyof typeof EventType];
@@ -107,6 +108,23 @@ export interface SessionAbandonedEvent extends EventBase {
   idleDays?: number;
 }
 
+/** Emitted by `pty gc` when a `strategy=permanent` session has fast-failed
+ *  its respawn `limit` consecutive times within `window` seconds. Marks the
+ *  session `strategy.status=flapping` and stops respawning until the operator
+ *  removes the tag (or the stored command changes — auto-reset on hash
+ *  divergence). Emitted at the moment the threshold is crossed; subsequent
+ *  gc ticks silently skip the flapping session. */
+export interface SessionFlappingEvent extends EventBase {
+  type: "session_flapping";
+  /** Fast-fails counted, at or above `limit` when this event fired. */
+  counter: number;
+  /** Threshold that was crossed. */
+  limit: number;
+  /** Fast-fail window in seconds. A respawn that exits within this many
+   *  seconds of its `strategy.last-respawn-at` stamp counts as fast. */
+  window: number;
+}
+
 /** User-published event. `type` must begin with `user.` — the CLI
  *  (`pty emit`) rejects anything else, and the client-API `emitEvent`
  *  helper throws on bad types. Payload is free-form JSON. */
@@ -159,6 +177,7 @@ export type EventRecord =
   | SessionExecEvent
   | SessionRespawnEvent
   | SessionAbandonedEvent
+  | SessionFlappingEvent
   | UserEvent
   | StateSetEvent
   | StateDeleteEvent

--- a/src/sessions.ts
+++ b/src/sessions.ts
@@ -3,6 +3,7 @@ import * as fsp from "node:fs/promises";
 import * as path from "node:path";
 import * as os from "node:os";
 import * as net from "node:net";
+import { createHash } from "node:crypto";
 // Circular import: events.ts imports getEventsPath/ensureSessionDir from
 // this file. Cycle is safe — `appendEventSync` is only called at runtime
 // from inside functions, never at module-init time.
@@ -510,6 +511,43 @@ export interface GcResult {
    *  binary is on an unmounted volume). Cron interval is the rate limit;
    *  next tick tries again. */
   respawnFailed: { name: string; error: string }[];
+  /** Permanent sessions the fast-fail cap flipped to `flapping` on this
+   *  tick. Each entry records the counter at the moment of flip plus the
+   *  effective `limit`/`window` in play. Sessions already flagged before
+   *  this tick are silently skipped from the respawn loop and do NOT
+   *  appear here — this bucket is transitions only. */
+  flapped: { name: string; counter: number; limit: number; window: number }[];
+  /** Permanent sessions skipped this tick because they are already
+   *  `strategy.status=flapping`. Distinct from `flapped` (transitions),
+   *  `respawnFailed` (attempted + failed), and `respawned` (attempted +
+   *  succeeded). Consumers can render "N flapping" without having to
+   *  read tags themselves. */
+  flappingSkipped: string[];
+}
+
+/** Default fast-fail respawn cap window (seconds). A permanent session
+ *  that exits within `DEFAULT_FAST_FAIL_WINDOW_SEC` of its previous gc
+ *  respawn counts as a fast fail. Overridden by `opts.fastFailWindowSec`
+ *  or the per-session `strategy.fast-fail-window` tag. */
+export const DEFAULT_FAST_FAIL_WINDOW_SEC = 60;
+
+/** Default fast-fail limit. `DEFAULT_FAST_FAIL_LIMIT` consecutive fast
+ *  fails flip the session to `strategy.status=flapping` and stop future
+ *  respawns until the operator intervenes (or the stored command changes,
+ *  which auto-resets). Overridden by `opts.fastFailLimit` or the
+ *  per-session `strategy.fast-fail-limit` tag. */
+export const DEFAULT_FAST_FAIL_LIMIT = 3;
+
+/** SHA-256 of a session's respawn command line, used to auto-reset the
+ *  fast-fail counter when the operator edits the pty.toml (or otherwise
+ *  changes the stored command). Kept short — the tag surface is user-
+ *  facing, not a cryptographic identifier. */
+function commandFingerprint(command: string, args: string[]): string {
+  const h = createHash("sha256");
+  h.update(command);
+  h.update("\0");
+  h.update(args.join("\0"));
+  return h.digest("hex").slice(0, 16);
 }
 
 /** Reconciliation pass driven by `pty gc`. Stateless: every invocation
@@ -530,11 +568,26 @@ export interface GcResult {
  *         exited/vanished is respawned via `spawnDaemon` (lazy-imported to
  *         avoid the `sessions ↔ spawn` cycle). Sessions with `ptyfile` +
  *         `ptyfile.session` tags re-read the toml to pick up any edits.
+ *         A fast-fail cap prevents a crash-looping leaf from being
+ *         respawned forever: `strategy.fast-fail-limit` consecutive
+ *         respawns whose leaf exited within `strategy.fast-fail-window`
+ *         seconds flip the session to `strategy.status=flapping` and
+ *         skip it on subsequent ticks. Auto-reset when the stored command
+ *         changes; manual reset via `pty tag <name> --rm strategy.status`.
  *    3.   Existing sweep: the historic behavior — exited/vanished sessions
  *         that aren't permanent get `cleanupAll`'d. */
-export async function gc(opts: { dryRun?: boolean; idleDays?: number } = {}): Promise<GcResult> {
+export async function gc(
+  opts: {
+    dryRun?: boolean;
+    idleDays?: number;
+    fastFailWindowSec?: number;
+    fastFailLimit?: number;
+  } = {},
+): Promise<GcResult> {
   const dryRun = !!opts.dryRun;
   const globalIdleDays = opts.idleDays;
+  const globalFastFailWindow = opts.fastFailWindowSec;
+  const globalFastFailLimit = opts.fastFailLimit;
   // First call to `listSessions` is intentionally throwaway — it has a
   // side effect (`cleanupSocket`) on sessions whose daemon SIGKILL'd
   // without writing an exit record, and those sessions are then *missing*
@@ -630,16 +683,83 @@ export async function gc(opts: { dryRun?: boolean; idleDays?: number } = {}): Pr
     : await listSessions();
   const respawned: GcResult["respawned"] = [];
   const respawnFailed: GcResult["respawnFailed"] = [];
+  const flapped: GcResult["flapped"] = [];
+  const flappingSkipped: GcResult["flappingSkipped"] = [];
   for (const s of afterStep15) {
     if (s.metadata?.tags?.strategy !== "permanent") continue;
     if (!isGone(s.status)) continue;
     const ptyfileReread = !!s.metadata?.tags?.ptyfile;
+
+    // Fast-fail classifier: was the previous respawn a fast crash? What's
+    // the running counter? Should we flip to flapping? Runs before any
+    // spawn so a session at the limit boundary flaps this tick instead
+    // of respawning one more time.
+    const decision = classifyFlapping(
+      s,
+      new Date(),
+      globalFastFailWindow,
+      globalFastFailLimit,
+    );
+
+    if (decision.action === "skip-flapping") {
+      flappingSkipped.push(s.name);
+      continue;
+    }
+
     if (dryRun) {
+      if (decision.action === "flap-now") {
+        flapped.push({
+          name: s.name,
+          counter: decision.counter,
+          limit: decision.effectiveLimit,
+          window: decision.effectiveWindow,
+        });
+        continue;
+      }
       respawned.push({ name: s.name, ptyfileReread });
       continue;
     }
+
+    if (decision.action === "flap-now") {
+      // Persist the flapping mark to on-disk metadata so subsequent
+      // ticks see it. We update the metadata file directly instead of
+      // going through updateTags — the session's daemon is gone, there's
+      // no live connection to notify, and cleanupAll ordering constraints
+      // in respawnPermanent don't apply here (we're NOT respawning).
+      try {
+        const meta = readMetadata(s.name);
+        if (meta) {
+          const merged: Record<string, string> = {
+            ...(meta.tags ?? {}),
+            ...decision.newBookkeeping,
+          };
+          writeMetadata(s.name, { ...meta, tags: merged });
+        }
+      } catch {
+        // Best-effort — if we can't persist the flag now, the next tick
+        // will recompute the same decision and try again.
+      }
+      try {
+        appendEventSync(s.name, {
+          session: s.name,
+          type: "session_flapping",
+          ts: new Date().toISOString(),
+          counter: decision.counter,
+          limit: decision.effectiveLimit,
+          window: decision.effectiveWindow,
+        });
+      } catch {}
+      flapped.push({
+        name: s.name,
+        counter: decision.counter,
+        limit: decision.effectiveLimit,
+        window: decision.effectiveWindow,
+      });
+      continue;
+    }
+
     try {
-      await respawnPermanent(s.name, s.metadata!);
+      await respawnPermanent(s.name, s.metadata!, decision.newBookkeeping);
       respawned.push({ name: s.name, ptyfileReread });
     } catch (err: any) {
       respawnFailed.push({ name: s.name, error: err?.message ?? String(err) });
@@ -660,7 +780,15 @@ export async function gc(opts: { dryRun?: boolean; idleDays?: number } = {}): Pr
     removed.push(s.name);
   }
 
-  return { removed, killedOrphanChildren, abandoned, respawned, respawnFailed };
+  return {
+    removed,
+    killedOrphanChildren,
+    abandoned,
+    respawned,
+    respawnFailed,
+    flapped,
+    flappingSkipped,
+  };
 }
 
 /** Decide whether a permanent session is abandoned. Order:
@@ -708,6 +836,132 @@ function classifyAbandoned(
   return { reason: "idle", idleDays: ageDays };
 }
 
+/** Decide whether a `strategy=permanent` session that's exited/vanished
+ *  should be respawned, marked flapping, or silently skipped because
+ *  it's already flapping. Reads three bookkeeping tags from the session:
+ *    - `strategy.last-respawn-at` (ISO ts): when gc last respawned it
+ *    - `strategy.consecutive-fast-fails` (int): running fast-fail counter
+ *    - `strategy.command-hash` (16-char hex): command fingerprint at last
+ *      respawn. If the current fingerprint differs, the operator edited
+ *      the pty.toml (or otherwise changed the command); reset the
+ *      counter and clear any stale `strategy.status=flapping`.
+ *
+ *  Effective window/limit resolution:
+ *    per-session tag (strategy.fast-fail-window / -limit)
+ *    → global opt (CLI --fast-fail-window / --fast-fail-limit)
+ *    → DEFAULT_FAST_FAIL_WINDOW_SEC / DEFAULT_FAST_FAIL_LIMIT.
+ *
+ *  Returned `newBookkeeping` MUST be merged onto the session's tags map
+ *  before/instead of respawn. The `flap-now` action never respawns; the
+ *  `respawn` action does; the `skip-flapping` action skips entirely. */
+interface FlappingDecision {
+  action: "respawn" | "flap-now" | "skip-flapping";
+  effectiveWindow: number;
+  effectiveLimit: number;
+  /** Fast-fail counter after this tick's classification. Only meaningful
+   *  for `respawn` (stamped on the session) and `flap-now` (the counter
+   *  that crossed the threshold, surfaced in the event payload). */
+  counter: number;
+  /** Tag deltas to persist. Empty for `skip-flapping`. For `respawn`,
+   *  carries the fresh timestamp, counter, and command hash. For
+   *  `flap-now`, adds `strategy.status=flapping` on top. */
+  newBookkeeping: Record<string, string>;
+}
+
+function classifyFlapping(
+  s: SessionInfo,
+  now: Date,
+  globalWindowSec: number | undefined,
+  globalLimit: number | undefined,
+): FlappingDecision {
+  const tags = s.metadata?.tags ?? {};
+
+  const tagWindow = parseInt(tags["strategy.fast-fail-window"] ?? "", 10);
+  const effectiveWindow = Number.isFinite(tagWindow) && tagWindow > 0
+    ? tagWindow
+    : (globalWindowSec !== undefined && globalWindowSec > 0
+      ? globalWindowSec
+      : DEFAULT_FAST_FAIL_WINDOW_SEC);
+
+  const tagLimit = parseInt(tags["strategy.fast-fail-limit"] ?? "", 10);
+  const effectiveLimit = Number.isFinite(tagLimit) && tagLimit > 0
+    ? tagLimit
+    : (globalLimit !== undefined && globalLimit > 0
+      ? globalLimit
+      : DEFAULT_FAST_FAIL_LIMIT);
+
+  const command = s.metadata?.command ?? "";
+  const args = s.metadata?.args ?? [];
+  const currentHash = commandFingerprint(command, args);
+  const storedHash = tags["strategy.command-hash"];
+  const commandChanged = storedHash !== undefined && storedHash !== currentHash;
+
+  // Command change wins over an existing flapping mark: the operator has
+  // edited the pty.toml (or manually mutated the command), so give it a
+  // fresh chance. `strategy.status` clears; counter resets to 0.
+  if (tags["strategy.status"] === "flapping" && !commandChanged) {
+    return {
+      action: "skip-flapping",
+      effectiveWindow,
+      effectiveLimit,
+      counter: parseInt(tags["strategy.consecutive-fast-fails"] ?? "0", 10) || 0,
+      newBookkeeping: {},
+    };
+  }
+
+  // Was the previous respawn a fast fail? Compare the exit timestamp
+  // against the last-respawn stamp; anything under `window` seconds is
+  // fast. If no prior stamp exists (never respawned by gc) or the exit
+  // is missing (vanished session), treat as slow — the counter resets.
+  const lastRespawnAt = tags["strategy.last-respawn-at"];
+  const exitedAt = s.metadata?.exitedAt;
+  let liveMs: number | null = null;
+  if (lastRespawnAt && exitedAt) {
+    const lr = Date.parse(lastRespawnAt);
+    const ex = Date.parse(exitedAt);
+    if (Number.isFinite(lr) && Number.isFinite(ex)) liveMs = ex - lr;
+  }
+  const wasFastFail = liveMs !== null && liveMs >= 0 && liveMs < effectiveWindow * 1000;
+
+  const prevCounter = parseInt(tags["strategy.consecutive-fast-fails"] ?? "0", 10) || 0;
+  const nextCounter = commandChanged ? 0 : (wasFastFail ? prevCounter + 1 : 0);
+
+  if (nextCounter >= effectiveLimit) {
+    // Threshold crossed. Mark flapping, don't respawn. The counter goes
+    // into the tags at its final value so subsequent listers can see how
+    // deep the streak went.
+    const bookkeeping: Record<string, string> = {
+      "strategy.status": "flapping",
+      "strategy.consecutive-fast-fails": String(nextCounter),
+      "strategy.command-hash": currentHash,
+    };
+    if (lastRespawnAt) bookkeeping["strategy.last-respawn-at"] = lastRespawnAt;
+    return {
+      action: "flap-now",
+      effectiveWindow,
+      effectiveLimit,
+      counter: nextCounter,
+      newBookkeeping: bookkeeping,
+    };
+  }
+
+  // Respawn. Stamp fresh bookkeeping. If we're clearing a stale flap
+  // mark from a command change, drop `strategy.status` explicitly by
+  // storing an empty string — updateTags treats that as a remove.
+  const bookkeeping: Record<string, string> = {
+    "strategy.last-respawn-at": now.toISOString(),
+    "strategy.consecutive-fast-fails": String(nextCounter),
+    "strategy.command-hash": currentHash,
+  };
+  return {
+    action: "respawn",
+    effectiveWindow,
+    effectiveLimit,
+    counter: nextCounter,
+    newBookkeeping: bookkeeping,
+  };
+}
+
 /** Restart a `strategy=permanent` session whose daemon is gone. If the
  *  session was toml-managed (`ptyfile` + `ptyfile.session` tags), re-read
  *  the pty.toml so the new daemon picks up command/env edits since the
@@ -715,10 +969,19 @@ function classifyAbandoned(
  *  verbatim (last-known-good) so a temporarily-missing toml doesn't
  *  prevent restart.
  *
+ *  `bookkeepingOverlay` (optional) carries pty-internal tags that must
+ *  survive the pty.toml re-read: gc backoff state (`strategy.last-*`,
+ *  `strategy.command-hash`, `strategy.consecutive-fast-fails`). Passed
+ *  by `gc()` STEP-2; ignored by other callers.
+ *
  *  Lazy-imports `spawn.ts` so the `sessions.ts ↔ spawn.ts` cycle doesn't
  *  bite at module-init time. After spawn, appends a `session_respawn`
  *  event to the session's event log so consumers see the restart. */
-async function respawnPermanent(name: string, metadata: SessionMetadata): Promise<void> {
+async function respawnPermanent(
+  name: string,
+  metadata: SessionMetadata,
+  bookkeepingOverlay: Record<string, string> = {},
+): Promise<void> {
   let command = metadata.command;
   let args = metadata.args;
   let displayCommand = metadata.displayCommand;
@@ -750,6 +1013,17 @@ async function respawnPermanent(name: string, metadata: SessionMetadata): Promis
       // error). Fall back to stored metadata — better to respawn with
       // last-known-good than to give up.
     }
+  }
+
+  // Merge gc's backoff bookkeeping last so it survives the pty.toml
+  // overlay above. Callers pass an empty overlay when they aren't gc.
+  // If a command change is clearing a stale flap mark, the caller
+  // omits `strategy.status` from the overlay; we also clear any
+  // existing flag on the merged map so a rebuilt tags dict doesn't
+  // silently carry it forward from the previous metadata.
+  tags = { ...(tags ?? {}), ...bookkeepingOverlay };
+  if (bookkeepingOverlay["strategy.status"] === undefined) {
+    delete tags["strategy.status"];
   }
 
   // Wipe stale socket/pid/events before respawn so spawnDaemon doesn't

--- a/tests/gc-flapping.test.ts
+++ b/tests/gc-flapping.test.ts
@@ -1,0 +1,320 @@
+// #54: fast-fail respawn cap. A crash-looping permanent session gets
+// flagged flapping and stopped after `strategy.fast-fail-limit`
+// consecutive fast failures within `strategy.fast-fail-window` seconds.
+// Auto-reset on command change; manual reset via `pty tag --rm`.
+
+import { describe, it, expect, afterEach, afterAll } from "vitest";
+import * as fs from "node:fs";
+import * as os from "node:os";
+import * as path from "node:path";
+import { fileURLToPath } from "node:url";
+import { spawnSync } from "node:child_process";
+import { createHash } from "node:crypto";
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const nodeBin = process.execPath;
+const cliPath = path.join(__dirname, "..", "dist", "cli.js");
+
+const testRoot = fs.mkdtempSync(path.join(os.tmpdir(), "pty-flap-"));
+afterAll(() => {
+  fs.rmSync(testRoot, { recursive: true, force: true, maxRetries: 3, retryDelay: 100 });
+});
+
+let sessionDirs: string[] = [];
+
+function makeSessionDir(): string {
+  const dir = fs.mkdtempSync(path.join(testRoot, "d-"));
+  sessionDirs.push(dir);
+  return dir;
+}
+
+let nameCounter = 0;
+function uniqueName(): string {
+  return `fl${++nameCounter}${Math.random().toString(36).slice(2, 5)}`;
+}
+
+function runCli(sessionDir: string, ...args: string[]) {
+  return spawnSync(nodeBin, [cliPath, ...args], {
+    env: { ...process.env, PTY_SESSION_DIR: sessionDir },
+    encoding: "utf-8",
+    timeout: 15000,
+  });
+}
+
+function readMeta(sessionDir: string, name: string): any {
+  return JSON.parse(fs.readFileSync(path.join(sessionDir, `${name}.json`), "utf-8"));
+}
+
+function readEvents(sessionDir: string, name: string): any[] {
+  const filePath = path.join(sessionDir, `${name}.events.jsonl`);
+  try {
+    return fs.readFileSync(filePath, "utf-8")
+      .trimEnd().split("\n").filter((l) => l.length > 0).map((l) => JSON.parse(l));
+  } catch {
+    return [];
+  }
+}
+
+/** Write a synthetic exited-permanent metadata file. `respawnAt` seeds
+ *  `strategy.last-respawn-at`, `exitedAt` seeds `metadata.exitedAt` —
+ *  their delta drives the fast-fail classifier. */
+function writeExitedPermanent(
+  sessionDir: string,
+  name: string,
+  opts: {
+    command?: string;
+    args?: string[];
+    tags?: Record<string, string>;
+    lastRespawnAt?: string;
+    exitedAt?: string;
+    counter?: number;
+    commandHash?: string;
+    status?: string;
+  },
+): void {
+  const command = opts.command ?? "sh";
+  const args = opts.args ?? ["-c", "exit 1"];
+  const tags: Record<string, string> = {
+    strategy: "permanent",
+    ...(opts.tags ?? {}),
+  };
+  if (opts.lastRespawnAt !== undefined) tags["strategy.last-respawn-at"] = opts.lastRespawnAt;
+  if (opts.counter !== undefined) tags["strategy.consecutive-fast-fails"] = String(opts.counter);
+  if (opts.commandHash !== undefined) tags["strategy.command-hash"] = opts.commandHash;
+  if (opts.status !== undefined) tags["strategy.status"] = opts.status;
+
+  fs.writeFileSync(path.join(sessionDir, `${name}.json`), JSON.stringify({
+    command, args, displayCommand: command,
+    cwd: os.tmpdir(),
+    createdAt: new Date(Date.now() - 10 * 60_000).toISOString(),
+    exitedAt: opts.exitedAt ?? new Date().toISOString(),
+    exitCode: 1,
+    tags,
+  }));
+  // Also write a stub events file so appendEventSync doesn't create
+  // orphaned JSONL. Some listSessions paths key off it.
+  const evPath = path.join(sessionDir, `${name}.events.jsonl`);
+  if (!fs.existsSync(evPath)) fs.writeFileSync(evPath, "");
+}
+
+function commandHash(command: string, args: string[]): string {
+  const h = createHash("sha256");
+  h.update(command);
+  h.update("\0");
+  h.update(args.join("\0"));
+  return h.digest("hex").slice(0, 16);
+}
+
+afterEach(() => {
+  for (const dir of sessionDirs) {
+    try {
+      for (const e of fs.readdirSync(dir)) { try { fs.unlinkSync(path.join(dir, e)); } catch {} }
+    } catch {}
+  }
+  sessionDirs = [];
+});
+
+describe("gc fast-fail respawn cap", () => {
+  it("dry-run: below-limit fast fails preview as respawn (no state mutation)", () => {
+    const dir = makeSessionDir();
+    const name = uniqueName();
+    // Session was respawned 5s ago, exited 1s later → fast fail (1s < 60s).
+    // Prior counter 1 → this tick would make it 2, still below limit 3.
+    const last = new Date(Date.now() - 5000).toISOString();
+    const exit = new Date(Date.now() - 4000).toISOString();
+    writeExitedPermanent(dir, name, {
+      lastRespawnAt: last, exitedAt: exit, counter: 1,
+      commandHash: commandHash("sh", ["-c", "exit 1"]),
+    });
+
+    const r = runCli(dir, "gc", "--dry-run");
+    expect(r.status).toBe(0);
+    expect(r.stdout).toMatch(new RegExp(`Would respawn: ${name}`));
+    expect(r.stdout).not.toContain("Would flap");
+    // Dry-run must not mutate tags on disk.
+    const meta = readMeta(dir, name);
+    expect(meta.tags["strategy.consecutive-fast-fails"]).toBe("1");
+    expect(meta.tags["strategy.status"]).toBeUndefined();
+  });
+
+  it("dry-run: at-limit tick previews Would flap and no respawn", () => {
+    const dir = makeSessionDir();
+    const name = uniqueName();
+    const last = new Date(Date.now() - 5000).toISOString();
+    const exit = new Date(Date.now() - 4000).toISOString();
+    // Prior counter 2 → this tick makes it 3, hits default limit → flap.
+    writeExitedPermanent(dir, name, {
+      lastRespawnAt: last, exitedAt: exit, counter: 2,
+      commandHash: commandHash("sh", ["-c", "exit 1"]),
+    });
+
+    const r = runCli(dir, "gc", "--dry-run");
+    expect(r.status).toBe(0);
+    expect(r.stdout).toMatch(new RegExp(`Would flap: ${name} \\(3 fast-fails in 60s, limit 3\\)`));
+    expect(r.stdout).not.toMatch(new RegExp(`Would respawn: ${name}`));
+
+    // No mutation on dry-run.
+    const meta = readMeta(dir, name);
+    expect(meta.tags["strategy.status"]).toBeUndefined();
+    expect(meta.tags["strategy.consecutive-fast-fails"]).toBe("2");
+  });
+
+  it("at-limit tick persists strategy.status=flapping and emits session_flapping", () => {
+    const dir = makeSessionDir();
+    const name = uniqueName();
+    const last = new Date(Date.now() - 5000).toISOString();
+    const exit = new Date(Date.now() - 4000).toISOString();
+    writeExitedPermanent(dir, name, {
+      lastRespawnAt: last, exitedAt: exit, counter: 2,
+      commandHash: commandHash("sh", ["-c", "exit 1"]),
+    });
+
+    const r = runCli(dir, "gc");
+    expect(r.status).toBe(0);
+    expect(r.stdout).toContain(`Flapping: ${name} (3 fast-fails in 60s, limit 3)`);
+
+    const meta = readMeta(dir, name);
+    expect(meta.tags["strategy.status"]).toBe("flapping");
+    expect(meta.tags["strategy.consecutive-fast-fails"]).toBe("3");
+
+    const events = readEvents(dir, name);
+    const flap = events.find((e) => e.type === "session_flapping");
+    expect(flap).toBeDefined();
+    expect(flap.counter).toBe(3);
+    expect(flap.limit).toBe(3);
+    expect(flap.window).toBe(60);
+  });
+
+  it("already-flapping session is silently skipped on subsequent tick", () => {
+    const dir = makeSessionDir();
+    const name = uniqueName();
+    writeExitedPermanent(dir, name, {
+      status: "flapping",
+      counter: 3,
+      lastRespawnAt: new Date(Date.now() - 60_000).toISOString(),
+      exitedAt: new Date(Date.now() - 55_000).toISOString(),
+      commandHash: commandHash("sh", ["-c", "exit 1"]),
+    });
+
+    const r = runCli(dir, "gc");
+    expect(r.status).toBe(0);
+    expect(r.stdout).toContain(`Skipped (flapping): ${name}`);
+    expect(r.stdout).not.toContain(`Respawned: ${name}`);
+
+    // No new events beyond what was already there.
+    const events = readEvents(dir, name);
+    expect(events.filter((e) => e.type === "session_flapping").length).toBe(0);
+  });
+
+  it("slow-fail (past window) resets the counter to 0", () => {
+    const dir = makeSessionDir();
+    const name = uniqueName();
+    // Last respawn 10 minutes ago, exited 9 minutes ago → 60s live, past
+    // the default 60s window (using an exit ~60m after respawn).
+    const last = new Date(Date.now() - 10 * 60_000).toISOString();
+    const exit = new Date(Date.now() - 5 * 60_000).toISOString();
+    writeExitedPermanent(dir, name, {
+      lastRespawnAt: last, exitedAt: exit, counter: 2,
+      commandHash: commandHash("sh", ["-c", "exit 1"]),
+    });
+
+    const r = runCli(dir, "gc", "--dry-run");
+    expect(r.status).toBe(0);
+    expect(r.stdout).toMatch(new RegExp(`Would respawn: ${name}`));
+    expect(r.stdout).not.toContain("Would flap");
+    // (Counter reset is verified via the "no flap at same prior counter"
+    // outcome — a fast fail at prior=2 would have flapped; slow-fail
+    // continues to respawn.)
+  });
+
+  it("command-hash change auto-resets counter and clears flapping mark", () => {
+    const dir = makeSessionDir();
+    const name = uniqueName();
+    // Session is currently flagged flapping under an old command hash.
+    // Metadata now reports a DIFFERENT command (operator edited pty.toml).
+    // The classifier should notice the divergence and both reset the
+    // counter and clear the flapping mark, letting gc respawn.
+    const oldHash = commandHash("sh", ["-c", "old-command"]);
+    writeExitedPermanent(dir, name, {
+      command: "sh", args: ["-c", "exit 1"],  // new command
+      status: "flapping", counter: 3,
+      lastRespawnAt: new Date(Date.now() - 5000).toISOString(),
+      exitedAt: new Date(Date.now() - 4000).toISOString(),
+      commandHash: oldHash,  // stale hash
+    });
+
+    const r = runCli(dir, "gc", "--dry-run");
+    expect(r.status).toBe(0);
+    expect(r.stdout).toMatch(new RegExp(`Would respawn: ${name}`));
+    expect(r.stdout).not.toContain("Skipped (flapping)");
+    expect(r.stdout).not.toContain("Would flap");
+  });
+
+  it("per-session strategy.fast-fail-limit overrides the default", () => {
+    const dir = makeSessionDir();
+    const name = uniqueName();
+    // Prior counter 1 + fast fail → this tick makes it 2. Default limit
+    // 3 would let it respawn; per-session limit 2 flaps instead.
+    writeExitedPermanent(dir, name, {
+      lastRespawnAt: new Date(Date.now() - 5000).toISOString(),
+      exitedAt: new Date(Date.now() - 4000).toISOString(),
+      counter: 1,
+      commandHash: commandHash("sh", ["-c", "exit 1"]),
+      tags: { "strategy.fast-fail-limit": "2" },
+    });
+
+    const r = runCli(dir, "gc", "--dry-run");
+    expect(r.status).toBe(0);
+    expect(r.stdout).toMatch(new RegExp(`Would flap: ${name} \\(2 fast-fails in 60s, limit 2\\)`));
+  });
+
+  it("--fast-fail-limit CLI flag applies to sessions without a per-session tag", () => {
+    const dir = makeSessionDir();
+    const name = uniqueName();
+    // Prior counter 4 + fast fail → 5. CLI flag lifts limit to 10 → still respawn.
+    writeExitedPermanent(dir, name, {
+      lastRespawnAt: new Date(Date.now() - 5000).toISOString(),
+      exitedAt: new Date(Date.now() - 4000).toISOString(),
+      counter: 4,
+      commandHash: commandHash("sh", ["-c", "exit 1"]),
+    });
+
+    const r = runCli(dir, "gc", "--dry-run", "--fast-fail-limit=10");
+    expect(r.status).toBe(0);
+    expect(r.stdout).toMatch(new RegExp(`Would respawn: ${name}`));
+    expect(r.stdout).not.toContain("Would flap");
+  });
+
+  it("per-session strategy.fast-fail-window overrides the default", () => {
+    const dir = makeSessionDir();
+    const name = uniqueName();
+    // Live time = 30s. Default window 60s → fast fail. Per-session window
+    // 10s → slow fail (30 > 10) → counter resets → respawn, no flap.
+    writeExitedPermanent(dir, name, {
+      lastRespawnAt: new Date(Date.now() - 30_000).toISOString(),
+      exitedAt: new Date(Date.now() - 0).toISOString(),
+      counter: 2,
+      commandHash: commandHash("sh", ["-c", "exit 1"]),
+      tags: { "strategy.fast-fail-window": "10" },
+    });
+
+    const r = runCli(dir, "gc", "--dry-run");
+    expect(r.status).toBe(0);
+    expect(r.stdout).toMatch(new RegExp(`Would respawn: ${name}`));
+    expect(r.stdout).not.toContain("Would flap");
+  });
+
+  it("no prior last-respawn-at (first respawn ever) doesn't count as fast fail", () => {
+    const dir = makeSessionDir();
+    const name = uniqueName();
+    // Session exited fresh — no last-respawn-at tag yet. Counter absent.
+    writeExitedPermanent(dir, name, {
+      exitedAt: new Date().toISOString(),
+    });
+
+    const r = runCli(dir, "gc", "--dry-run");
+    expect(r.status).toBe(0);
+    expect(r.stdout).toMatch(new RegExp(`Would respawn: ${name}`));
+    expect(r.stdout).not.toContain("Would flap");
+  });
+});


### PR DESCRIPTION
Fixes #54.

## Summary

Adds systemd-style `StartLimitIntervalSec`/`StartLimitBurst` semantics to `pty gc`'s permanent-session respawn loop. A crash-looping leaf (`sh -c 'exit 1'` tagged permanent, or a resume-id that no longer exists) no longer respawns every tick forever — after a configurable streak of fast fails within a window, the session is flagged `strategy.status=flapping` and skipped until the operator or a command change intervenes.

## Design

**Fast fail = leaf exit within `window` seconds of the previous gc respawn.** The classifier reads three bookkeeping tags off the session:

- `strategy.last-respawn-at` — ISO timestamp of the previous gc respawn (absent on first respawn).
- `strategy.consecutive-fast-fails` — running counter.
- `strategy.command-hash` — 16-char SHA-256 prefix of the respawn command line. Used to auto-reset on operator edit.

Effective window/limit resolution: **per-session tag > CLI global > default (60s / 3)**. Same precedence shape as `--idle-days` from #47/#50.

At the moment the counter would hit `limit`, gc:
1. Writes `strategy.status=flapping` on the session's metadata (direct disk write; the daemon is gone).
2. Emits a `session_flapping` event with `{ counter, limit, window }`.
3. Skips respawn.
4. Reports `Flapping: <name> (<N> fast-fails in <W>s, limit <L>)`.

Subsequent gc ticks see `strategy.status=flapping` and silently skip, reporting `Skipped (flapping): <name>`.

**Reset paths** (both no-code):
- Manual: `pty tag <name> --rm strategy.status`.
- Automatic on command change: the classifier compares the current fingerprint against `strategy.command-hash`. Divergence → counter resets to 0 AND flapping mark clears, letting gc retry.

## Public API additions

- **Event `session_flapping`** — new type in `EventType`; interface `SessionFlappingEvent extends EventBase`. Documented in `docs/disk-layout.md`.
- **`GcResult.flapped: { name, counter, limit, window }[]`** — transitions on this tick.
- **`GcResult.flappingSkipped: string[]`** — silently-skipped-because-already-flagged.
- **CLI: `pty gc --fast-fail-window=<sec> --fast-fail-limit=<int>`** — mirrors `--idle-days` shape.
- **Tags: `strategy.fast-fail-window=<sec>`, `strategy.fast-fail-limit=<int>`** — per-session overrides; `strategy.last-respawn-at`, `strategy.consecutive-fast-fails`, `strategy.command-hash`, `strategy.status=flapping` — bookkeeping written by gc.

All additive; existing consumers keep working. gc's stateless-reconciliation contract preserved — no supervisor state file, no in-memory counters, everything on-disk under the session's metadata.

## What's NOT in this PR

- `pty restart` / `pty up` don't currently auto-clear the flapping mark. Manual `pty tag --rm strategy.status` (or a command edit) is the reset path. If this shape reads awkward on the walk, I'll add flap-clearing to `cmdRestart` in a follow-up.
- No global config file for the defaults — just CLI flag + tag. Matches `--idle-days` precedent.
- No `pty list` badge for `strategy.status=flapping`. `pty list --tags` shows it. Could add a `[flapping]` marker analogous to `[permanent]` if you want; small delta if so.

## Test plan

- [x] `tests/gc-flapping.test.ts` (10 new): dry-run below-limit → Would respawn; dry-run at-limit → Would flap; at-limit tick persists `strategy.status=flapping` + emits `session_flapping`; already-flagged session silently skipped; slow-fail (past window) counter reset; command-hash auto-reset clears flapping mark; per-session `strategy.fast-fail-limit` overrides default; CLI `--fast-fail-limit=N` applies to sessions without a per-session tag; per-session `strategy.fast-fail-window` overrides default; first-respawn (no prior last-respawn-at) doesn't count as fast fail.
- [x] Full suite: **1224 passed, 21 skipped, 0 failed**. Suite grew from 1214 → 1224 (my 10). Zero regressions.