### PR TITLE
follow-ups: restart/up clear flap mark, [flapping] badge, PTY_ROOT length backstop

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 ## Unreleased
 
+### Follow-ups to #56 (fast-fail cap) + PTY_ROOT length backstop
+
+- **`pty restart` and `pty up` now clear the `pty gc` flapping bookkeeping.** Manual restart is an operator "please try again" signal — dropping `strategy.status`, `strategy.consecutive-fast-fails`, `strategy.last-respawn-at`, and `strategy.command-hash` on the restarted session gives it a clean slate, so the next `pty gc` tick isn't a no-op (silent skip against a stale flapping flag). Auto-reset on command-hash divergence already handled the toml-edit case; this handles the operator-intervenes-without-edit case that gc otherwise can't infer. Applies to both `pty restart` and `pty up`'s "already running, tag-sync" path.
+- **`pty list` renders `[flapping]`** in place of `[permanent]` when a session carries `strategy.status=flapping`. Red instead of yellow — the flag stands out from ordinary permanent sessions because the operator's expectation has changed (`pty gc` has stopped respawning it on purpose).
+- **Startup-time PTY_ROOT length backstop.** When the resolved root's byte length + a default-shape `/<8-char-id>.sock` suffix (14 bytes) would exceed the `sockaddr_un.sun_path` 104-byte kernel limit, `pty` errors before any subcommand runs. The error names the root and points the finger at the root, not the session name — the previous fallthrough error at spawn time read as if a random-id name were the problem. Backstop respects `--root <shorter>` overrides.
+- Tests in `tests/gc-flap-clear-badge-root-len.test.ts` (7 new) cover: restart-clears-bookkeeping, list shows [flapping] and hides [permanent] when both would apply, list still shows [permanent] otherwise, backstop errors on `pty list` with too-deep root, backstop fires before subcommand parsing, root at the usable threshold succeeds, `--root <shorter>` overrides a too-long env.
+
 ### `pty gc` fast-fail respawn cap (fixes #54)
 
 - **New:** `pty gc` STEP-2 now detects a crash-looping permanent session and stops respawning it before it churns forever. A respawn whose leaf exits within `strategy.fast-fail-window` seconds (default 60) of the previous respawn counts as a fast fail; after `strategy.fast-fail-limit` consecutive fast fails (default 3) the session gets `strategy.status=flapping` written to its tags and a `session_flapping` event, and subsequent gc ticks silently skip it. This is the crash-loop-with-live-cwd case that the earlier `cwd-gone`/`idle` reap (#47, #50) didn't cover.

--- a/README.md
+++ b/README.md
@@ -268,10 +268,13 @@ Restart is stateless — every `pty gc` invocation re-derives intent from on-dis
 
 **Fast-fail cap** — a permanent session whose leaf exits within `strategy.fast-fail-window` seconds of its previous `pty gc` respawn counts as a fast fail. After `strategy.fast-fail-limit` consecutive fast fails, `pty gc` writes `strategy.status=flapping` on the session, emits a `session_flapping` event, and stops respawning it. Subsequent gc ticks print `Skipped (flapping): <name>` and take no action. Defaults: 60 s window, 3 consecutive fast fails.
 
+A flagged session shows `[flapping]` (red) in `pty list` in place of `[permanent]` — the operator's expectation has changed, so the badge reflects that.
+
 Reset a flagged session with one of:
 
-- `pty tag <name> --rm strategy.status` — clear the mark, `pty gc` retries on the next tick.
-- Edit the session's `pty.toml` command — the classifier notices the SHA-256 fingerprint change and auto-resets the counter and mark.
+- `pty restart <name>` or `pty up` — the manual respawn drops all fast-fail bookkeeping (`strategy.status`, `strategy.consecutive-fast-fails`, `strategy.last-respawn-at`, `strategy.command-hash`), treating restart as an operator "please try again" signal.
+- `pty tag <name> --rm strategy.status` — surgical reset that clears only the mark, leaving the counter intact for observability.
+- Edit the session's `pty.toml` command — the classifier notices the SHA-256 fingerprint change and auto-resets the counter and mark on the next gc tick.
 
 Per-session overrides tune the cap without editing gc's globals:
 

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -224,6 +224,37 @@ async function main(): Promise<void> {
     args.splice(rootIdx, 2);
   }
 
+  // Fail-loud backstop for the sockaddr_un.sun_path 104-byte kernel limit.
+  // `validateName()` already catches a too-long root at spawn time by
+  // computing the full socket path, but its error message reads as if
+  // the name were the problem, and it fires per-invocation only when a
+  // spawn happens. This check catches the pathological deep-PTY_ROOT
+  // case at startup — before any subcommand runs — and points the
+  // finger at the root, not the name.
+  //
+  // Threshold: an 8-char random session id (the default `pty run`
+  // shape) produces a socket suffix of `/xxxxxxxx.sock` = 14 bytes.
+  // A root whose length + 14 exceeds 104 can't host a default-id
+  // session and is unusable. Callers who intentionally want tiny
+  // 1-char names on a nearly-full root can side-step by shortening
+  // the root; there's no correct behavior for a genuinely-too-long
+  // root, so we fail rather than limp.
+  const resolvedRoot = process.env.PTY_ROOT ?? process.env.PTY_SESSION_DIR;
+  if (resolvedRoot && resolvedRoot.length > 0) {
+    const SUN_PATH_MAX = 104;
+    const SOCK_SUFFIX_BYTES = "/".length + 8 + ".sock".length;
+    const rootBytes = Buffer.byteLength(resolvedRoot, "utf-8");
+    if (rootBytes + SOCK_SUFFIX_BYTES > SUN_PATH_MAX) {
+      const usable = SUN_PATH_MAX - SOCK_SUFFIX_BYTES;
+      console.error(
+        `pty: PTY_ROOT is too long — ${rootBytes} bytes; must be ≤ ${usable} bytes for the socket path to fit the ${SUN_PATH_MAX}-byte kernel limit.\n` +
+        `  root: ${resolvedRoot}\n` +
+        `  Shorten the root (or use \`pty --root <shorter-path>\` for a one-off).`
+      );
+      process.exit(1);
+    }
+  }
+
   // Interactive-mode flags (--preselect-new, --filter-tag) can appear before
   // the subcommand. Peek at the subcommand without consuming flags; if it's
   // the interactive TUI (none, "i", or "interactive"), consume those flags
@@ -2637,6 +2668,20 @@ async function cmdUp(dir: string | undefined, names: string[]): Promise<void> {
       const newKeySet = new Set(userTomlKeys);
       const removals = prevTomlKeys.filter((k) => !newKeySet.has(k));
 
+      // Manual `pty up` is an operator "reset" signal, same shape as
+      // `pty restart` in cmdRestart above. Drop any `pty gc` flapping
+      // bookkeeping the session may have accumulated so a re-`pty up`
+      // gives the session a clean slate. These keys are gc-owned, never
+      // toml-declared, so they aren't in `prevTomlKeys`.
+      for (const k of [
+        "strategy.status",
+        "strategy.consecutive-fast-fails",
+        "strategy.last-respawn-at",
+        "strategy.command-hash",
+      ]) {
+        if (currentTags[k] !== undefined && !removals.includes(k)) removals.push(k);
+      }
+
       const label = bound.metadata?.displayName ?? bound.name;
       if (Object.keys(updates).length > 0 || removals.length > 0) {
         try {
@@ -2831,7 +2876,13 @@ async function cmdRestart(
   }
 
   cleanupAll(name);
-  await spawnDaemon({ name, command: meta.command, args: meta.args, displayCommand: meta.displayCommand, cwd: meta.cwd, tags: meta.tags });
+  // Manual restart is an operator "please try again" signal — drop any
+  // `strategy.status=flapping` mark and its bookkeeping so the fresh
+  // spawn isn't skipped by `pty gc` on the next tick. Auto-reset on
+  // command edit already clears these; this handles the operator-
+  // intervenes-without-edit case that gc otherwise can't infer.
+  const restartTags = clearFlappingBookkeeping(meta.tags);
+  await spawnDaemon({ name, command: meta.command, args: meta.args, displayCommand: meta.displayCommand, cwd: meta.cwd, tags: restartTags });
   console.log(`Session "${name}" restarted.`);
 
   // Nesting guard: restart itself is fine, but attaching would nest a client
@@ -2960,8 +3011,36 @@ function ask(prompt: string): Promise<string> {
   });
 }
 
+/** Strip `pty gc`'s flapping bookkeeping from a tag map before a manual
+ *  restart / respawn. `strategy.status`, `strategy.consecutive-fast-fails`,
+ *  `strategy.last-respawn-at`, and `strategy.command-hash` are all
+ *  gc-owned — they exist to track auto-respawn state, and an operator
+ *  action ("please try again") is a signal to reset them. Returns
+ *  `undefined` when the input is missing/empty so downstream defaults
+ *  (spawnDaemon skips the `tags` field entirely) apply. */
+function clearFlappingBookkeeping(
+  tags: Record<string, string> | undefined,
+): Record<string, string> | undefined {
+  if (!tags || Object.keys(tags).length === 0) return tags;
+  const out: Record<string, string> = {};
+  for (const [k, v] of Object.entries(tags)) {
+    if (k === "strategy.status") continue;
+    if (k === "strategy.consecutive-fast-fails") continue;
+    if (k === "strategy.last-respawn-at") continue;
+    if (k === "strategy.command-hash") continue;
+    out[k] = v;
+  }
+  return Object.keys(out).length > 0 ? out : undefined;
+}
+
 function strategyMarker(tags?: Record<string, string>): string {
   if (!tags) return "";
+  // Flapping supersedes permanent visually because it's what changed the
+  // operator's expectation ("gc stopped respawning this on purpose").
+  // Rendered red so it stands out from the yellow [permanent].
+  if (tags["strategy.status"] === "flapping") {
+    return " \x1b[31m[flapping]\x1b[0m";
+  }
   if (tags.strategy === "permanent") return " \x1b[33m[permanent]\x1b[0m";
   return "";
 }

--- a/tests/gc-flap-clear-badge-root-len.test.ts
+++ b/tests/gc-flap-clear-badge-root-len.test.ts
@@ -1,0 +1,223 @@
+// Follow-ups to #56:
+//   1. `pty restart` clears strategy.status=flapping + bookkeeping.
+//   2. `pty up` clears the same on the "already running, tag-sync" path.
+//   3. `pty list` renders `[flapping]` badge (mutually exclusive with [permanent]).
+//   4. Fail-loud startup backstop when PTY_ROOT is too long for the socket-path
+//      kernel limit — errors before any subcommand runs.
+
+import { describe, it, expect, afterEach, afterAll } from "vitest";
+import * as fs from "node:fs";
+import * as os from "node:os";
+import * as path from "node:path";
+import { fileURLToPath } from "node:url";
+import { spawnSync } from "node:child_process";
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const nodeBin = process.execPath;
+const cliPath = path.join(__dirname, "..", "dist", "cli.js");
+
+const testRoot = fs.mkdtempSync(path.join(os.tmpdir(), "pty-follow-"));
+afterAll(() => {
+  fs.rmSync(testRoot, { recursive: true, force: true, maxRetries: 3, retryDelay: 100 });
+});
+
+let sessionDirs: string[] = [];
+function makeSessionDir(): string {
+  const dir = fs.mkdtempSync(path.join(testRoot, "d-"));
+  sessionDirs.push(dir);
+  return dir;
+}
+
+let nameCounter = 0;
+function uniqueName(): string {
+  return `fc${++nameCounter}${Math.random().toString(36).slice(2, 5)}`;
+}
+
+function runCli(sessionDir: string, ...args: string[]) {
+  return spawnSync(nodeBin, [cliPath, ...args], {
+    env: { ...process.env, PTY_SESSION_DIR: sessionDir },
+    encoding: "utf-8",
+    timeout: 15000,
+  });
+}
+
+function readMeta(sessionDir: string, name: string): any {
+  return JSON.parse(fs.readFileSync(path.join(sessionDir, `${name}.json`), "utf-8"));
+}
+
+/** Write metadata simulating an exited session that gc previously marked
+ *  flapping. Includes all four bookkeeping tags. */
+function writeFlappingExited(
+  sessionDir: string,
+  name: string,
+  extraTags: Record<string, string> = {},
+): void {
+  fs.writeFileSync(path.join(sessionDir, `${name}.json`), JSON.stringify({
+    command: "sh", args: ["-c", "exit 1"], displayCommand: "sh -c 'exit 1'",
+    cwd: os.tmpdir(),
+    createdAt: new Date(Date.now() - 10 * 60_000).toISOString(),
+    exitedAt: new Date().toISOString(),
+    exitCode: 1,
+    tags: {
+      strategy: "permanent",
+      "strategy.status": "flapping",
+      "strategy.consecutive-fast-fails": "3",
+      "strategy.last-respawn-at": new Date(Date.now() - 5000).toISOString(),
+      "strategy.command-hash": "0123456789abcdef",
+      ...extraTags,
+    },
+  }));
+  const evPath = path.join(sessionDir, `${name}.events.jsonl`);
+  if (!fs.existsSync(evPath)) fs.writeFileSync(evPath, "");
+}
+
+afterEach(() => {
+  for (const dir of sessionDirs) {
+    try {
+      for (const e of fs.readdirSync(dir)) { try { fs.unlinkSync(path.join(dir, e)); } catch {} }
+    } catch {}
+  }
+  sessionDirs = [];
+});
+
+describe("pty restart clears strategy.status=flapping + bookkeeping", () => {
+  it("restart of a flapping-exited session drops all four gc bookkeeping tags", async () => {
+    const dir = makeSessionDir();
+    const name = uniqueName();
+    writeFlappingExited(dir, name, { role: "test" });
+
+    // Restart it. -y skips the prompt; command is "sh -c 'exit 1'" which
+    // will exit almost immediately — that's fine, we care about the tag
+    // snapshot right after spawn.
+    const r = runCli(dir, "restart", "-y", name);
+    expect(r.status).toBe(0);
+
+    // Give the daemon a moment to write its metadata.
+    await new Promise((res) => setTimeout(res, 300));
+
+    const meta = readMeta(dir, name);
+    expect(meta.tags.strategy).toBe("permanent");
+    expect(meta.tags.role).toBe("test");
+    // Bookkeeping tags are gone.
+    expect(meta.tags["strategy.status"]).toBeUndefined();
+    expect(meta.tags["strategy.consecutive-fast-fails"]).toBeUndefined();
+    expect(meta.tags["strategy.last-respawn-at"]).toBeUndefined();
+    expect(meta.tags["strategy.command-hash"]).toBeUndefined();
+  });
+});
+
+describe("pty list renders [flapping] badge", () => {
+  it("running session with strategy.status=flapping shows [flapping] in text output", () => {
+    const dir = makeSessionDir();
+    const name = uniqueName();
+    // Simulate a running session (synthetic pid + no exitedAt) with a
+    // flapping mark. `pty list` classifies status by (pid alive check +
+    // exited fields); we cheat by using our own pid so isProcessAlive
+    // returns true — the row renders as running.
+    fs.writeFileSync(path.join(dir, `${name}.json`), JSON.stringify({
+      command: "sh", args: [], displayCommand: "sh",
+      cwd: os.tmpdir(),
+      createdAt: new Date().toISOString(),
+      tags: {
+        strategy: "permanent",
+        "strategy.status": "flapping",
+      },
+    }));
+    fs.writeFileSync(path.join(dir, `${name}.pid`), String(process.pid));
+
+    const r = runCli(dir, "list");
+    expect(r.status).toBe(0);
+    // ANSI color-code stripped for the assertion; check the literal marker.
+    // `[flapping]` supersedes `[permanent]` when both would apply.
+    expect(r.stdout).toContain("[flapping]");
+    expect(r.stdout).not.toContain("[permanent]");
+  });
+
+  it("session without strategy.status=flapping still shows [permanent]", () => {
+    const dir = makeSessionDir();
+    const name = uniqueName();
+    fs.writeFileSync(path.join(dir, `${name}.json`), JSON.stringify({
+      command: "sh", args: [], displayCommand: "sh",
+      cwd: os.tmpdir(),
+      createdAt: new Date().toISOString(),
+      tags: { strategy: "permanent" },
+    }));
+    fs.writeFileSync(path.join(dir, `${name}.pid`), String(process.pid));
+
+    const r = runCli(dir, "list");
+    expect(r.status).toBe(0);
+    expect(r.stdout).toContain("[permanent]");
+    expect(r.stdout).not.toContain("[flapping]");
+  });
+});
+
+describe("PTY_ROOT length backstop", () => {
+  it("errors at startup when PTY_ROOT is too deep to fit the sockaddr_un limit", () => {
+    // Build a 95-byte path — well past the 90-byte usable threshold
+    // (104 − 14 for `/xxxxxxxx.sock`). Doesn't need to actually exist;
+    // the check is on byte length, not existence.
+    const tooLong = "/tmp/" + "a".repeat(95);
+    expect(Buffer.byteLength(tooLong, "utf-8")).toBeGreaterThan(90);
+
+    const r = spawnSync(nodeBin, [cliPath, "list"], {
+      env: { ...process.env, PTY_ROOT: tooLong, PTY_ROOT_LEGACY_SILENT: "1" },
+      encoding: "utf-8",
+      timeout: 5000,
+    });
+    expect(r.status).not.toBe(0);
+    expect(r.stderr).toMatch(/PTY_ROOT is too long/);
+    expect(r.stderr).toMatch(/104-byte kernel limit/);
+    // Points the finger at the root, not the name.
+    expect(r.stderr).toMatch(/Shorten the root/);
+  });
+
+  it("errors before any subcommand-specific parsing runs", () => {
+    // Backstop should fire even on a bogus subcommand — the too-long
+    // root is caught before dispatch.
+    const tooLong = "/tmp/" + "b".repeat(100);
+    const r = spawnSync(nodeBin, [cliPath, "definitely-not-a-real-subcommand"], {
+      env: { ...process.env, PTY_ROOT: tooLong, PTY_ROOT_LEGACY_SILENT: "1" },
+      encoding: "utf-8",
+      timeout: 5000,
+    });
+    expect(r.status).not.toBe(0);
+    expect(r.stderr).toMatch(/PTY_ROOT is too long/);
+    // The "unknown command" path is NOT hit; the root check errors first.
+    expect(r.stderr).not.toMatch(/Unknown command/);
+  });
+
+  it("allows a root right at the usable threshold", () => {
+    // Build a root at exactly 90 bytes — the maximum that leaves room
+    // for `/xxxxxxxx.sock` in 104. This should succeed (empty list).
+    const usable = 104 - ("/".length + 8 + ".sock".length);
+    const okRoot = "/tmp/" + "c".repeat(usable - "/tmp/".length);
+    expect(Buffer.byteLength(okRoot, "utf-8")).toBe(usable);
+    fs.mkdirSync(okRoot, { recursive: true });
+    try {
+      const r = spawnSync(nodeBin, [cliPath, "list", "--json"], {
+        env: { ...process.env, PTY_ROOT: okRoot, PTY_ROOT_LEGACY_SILENT: "1" },
+        encoding: "utf-8",
+        timeout: 5000,
+      });
+      expect(r.status).toBe(0);
+      expect(JSON.parse(r.stdout)).toEqual([]);
+    } finally {
+      try { fs.rmSync(okRoot, { recursive: true, force: true }); } catch {}
+    }
+  });
+
+  it("--root <shorter> overrides an env that would otherwise fail", () => {
+    // Env is too long; --root override is fine. The startup check reads
+    // process.env.PTY_ROOT *after* --root parsing has set it, so the
+    // override wins.
+    const tooLongEnv = "/tmp/" + "d".repeat(95);
+    const shortFlag = fs.mkdtempSync(path.join(testRoot, "shorter-"));
+    const r = spawnSync(nodeBin, [cliPath, "--root", shortFlag, "list", "--json"], {
+      env: { ...process.env, PTY_ROOT: tooLongEnv, PTY_ROOT_LEGACY_SILENT: "1" },
+      encoding: "utf-8",
+      timeout: 5000,
+    });
+    expect(r.status).toBe(0);
+    expect(JSON.parse(r.stdout)).toEqual([]);
+  });
+});


### PR DESCRIPTION
Three low-priority follow-ups to #55 (PTY_ROOT) and #56 (fast-fail cap), bundled per Nathan's steer.

## 1. `pty restart` and `pty up` clear the fast-fail bookkeeping

Manual restart is an operator "please try again" signal; the fresh spawn should NOT inherit the previous cycle's crash-loop tags. Dropping `strategy.status`, `strategy.consecutive-fast-fails`, `strategy.last-respawn-at`, and `strategy.command-hash` gives the restart a clean slate — the next `pty gc` tick isn't a silent no-op against a stale flag.

Auto-reset on command-hash divergence already handled the toml-edit case (`sessions.ts:classifyFlapping`). This closes the operator-intervenes-without-edit case that gc otherwise can't infer.

**Sites**:
- `cmdRestart`: applies `clearFlappingBookkeeping(meta.tags)` before `spawnDaemon`.
- `cmdUp`'s "already running, tag-sync" branch: adds the four bookkeeping keys to the `updateTags` `removals` array.

Fresh (non-bound) toml-spawns already start with clean tags via `tomlTags` construction; no change needed there.

## 2. `[flapping]` badge in `pty list`

`strategyMarker(tags)` now returns `\x1b[31m[flapping]\x1b[0m` (red) when `strategy.status === "flapping"`, superseding `[permanent]` (yellow). The flag stands out because the operator's expectation has changed — `pty gc` has stopped respawning on purpose. Mutually exclusive: a flapping session never shows both.

## 3. Startup-time PTY_ROOT length backstop

The `sockaddr_un.sun_path` 104-byte kernel limit was previously caught only at spawn time inside `validateName()`, and the error message read as if the session **name** were the problem. On a pathologically deep `PTY_ROOT`, no name fits — the correct answer is "shorten the root".

New check runs in `main()` right after `--root` / env resolution:
```
usable = 104 − ("/".length + 8 + ".sock".length) = 90 bytes
```
If `Buffer.byteLength(resolvedRoot, "utf-8") + 14 > 104`, error with a message that names the root and directs the caller at it. Respects `--root <shorter>` overrides — the check reads `process.env.PTY_ROOT` after `--root` has assigned into it.

Threshold picked from the default `pty run` shape (random 8-char id). Callers who intentionally want tiny 1-char names on a nearly-full root can side-step by shortening the root; there's no correct behavior for a genuinely-too-long root, so we fail rather than limp.

## Test plan

- [x] `tests/gc-flap-clear-badge-root-len.test.ts` (7 new): restart clears bookkeeping; list shows [flapping] and hides [permanent] when both would apply; list still shows [permanent] otherwise; backstop errors on `pty list` with too-deep root; backstop fires before subcommand parsing; root at the usable threshold succeeds; `--root <shorter>` overrides a too-long env.
- [x] Full suite: **1231 passed, 21 skipped, 0 failed** (up from 1224 in #56).

## Not in this PR

- No `session_flapping_cleared` event on the manual reset. Considered but rejected — the operator's action is visible in shell history + `tags_change` event fires from `updateTags`. Adding another event type is noise.
- No badge in `pty stats` output — that's a metrics view, badges are for the session list.