### PR TITLE
tui: text() accepts { fg, bold, ... } object form; bump 0.11.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,11 @@
 # Changelog
 
-## Unreleased
+## 0.11.0
+
+### `@myobie/pty/tui` — `text()` accepts an object form `{ fg, bold, ... }`
+
+- `text()` gains a second calling shape: `text(str, { fg: someColor, bold: true, italic: true, ... })`. The `fg` key maps to the `color` slot; the rest are the existing `TextOpts`. The original positional shape `text(str, color?, opts?)` continues to work — dispatch is by second-arg TYPE (string / array → positional Color, plain object → opts-with-fg), not arity.
+- Motivation: consumers of the `@myobie/pty/tui` barrel that lay out `{ fg: ..., bold: ... }` maps ran headlong into a compile error (`'fg' does not exist`) when the object reached the positional-`color` slot. Both shapes now compose cleanly.
 
 ### Lean-core: `pty state` and `pty wrap` REMOVED (BREAKING)
 

--- a/flake.nix
+++ b/flake.nix
@@ -29,7 +29,7 @@
 
             # Generated from package-lock.json.
             # Regenerate with: nix run nixpkgs#prefetch-npm-deps -- package-lock.json
-            npmDepsHash = "sha256-y1hEiPG6kZLilTHF6dH7Ql/X9ddDBucsZYJqETlTuyE=";
+            npmDepsHash = "sha256-mer8rhDyD/j+htWDU8F1EH7MrnuS8pS57WdQgGH8cnQ=";
 
             # node-pty has native code that needs these at build time
             nativeBuildInputs = with pkgs; [ python3 pkg-config ];

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@myobie/pty",
-  "version": "0.10.0",
+  "version": "0.11.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@myobie/pty",
-      "version": "0.10.0",
+      "version": "0.11.0",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@myobie/pty",
-  "version": "0.10.0",
+  "version": "0.11.0",
   "description": "Persistent terminal sessions with detach/attach, plus a Playwright-style testing library for TUI apps",
   "type": "module",
   "license": "MIT",

--- a/src/tui/builders.ts
+++ b/src/tui/builders.ts
@@ -60,17 +60,41 @@ export function themeToXterm(theme: Theme): Record<string, string> {
   };
 }
 
+interface TextOpts {
+  bold?: boolean; dim?: boolean; italic?: boolean; inverse?: boolean;
+  background?: Color;
+  truncate?: boolean; wrap?: boolean;
+  highlight?: (text: string) => import("./nodes.ts").Span[];
+}
+
+/** Two shapes are supported:
+ *
+ *    text("hi")
+ *    text("hi", someColor)
+ *    text("hi", someColor, { bold: true })
+ *    text("hi", { fg: someColor, bold: true })  // object shape; `fg` maps to color
+ *
+ *  The object shape came in for consumers that prefer object-with-`fg` — everyone
+ *  ends up laying out `{ fg: ..., bold: ... }` anyway, so having to hop between
+ *  positional-color and object-opts was friction. Existing call sites keep working
+ *  because the runtime dispatch checks the second-arg TYPE, not arity: a string
+ *  (SemanticColor) or array ([r,g,b]) is a Color; a plain object is TextOpts. */
+export function text(str: string): TextNode;
+export function text(str: string, color: Color, opts?: TextOpts): TextNode;
+export function text(str: string, opts: TextOpts & { fg?: Color }): TextNode;
 export function text(
   str: string,
-  color?: Color,
-  opts?: {
-    bold?: boolean; dim?: boolean; italic?: boolean; inverse?: boolean;
-    background?: Color;
-    truncate?: boolean; wrap?: boolean;
-    highlight?: (text: string) => import("./nodes.ts").Span[];
-  },
+  colorOrOpts?: Color | (TextOpts & { fg?: Color }),
+  opts?: TextOpts,
 ): TextNode {
-  return { type: "text", text: str, color, ...opts };
+  if (colorOrOpts === undefined) return { type: "text", text: str };
+  if (typeof colorOrOpts === "string" || Array.isArray(colorOrOpts)) {
+    // Positional shape: colorOrOpts IS the Color.
+    return { type: "text", text: str, color: colorOrOpts, ...opts };
+  }
+  // Object shape: pull `fg` off as the color; the rest are ordinary opts.
+  const { fg, ...rest } = colorOrOpts;
+  return { type: "text", text: str, color: fg, ...rest };
 }
 
 export function spacer(): SpacerNode {

--- a/tests/tui-framework.test.ts
+++ b/tests/tui-framework.test.ts
@@ -34,6 +34,35 @@ describe("builders", () => {
     expect(n.color).toEqual([255, 0, 0]);
   });
 
+  it("text() object shape: { fg, bold, ... }", () => {
+    // Consumers that prefer the object form pass `fg` for the color and
+    // any TextOpts inline. `fg` maps to `color`; the rest spread as-is.
+    const n = text("hi", { fg: [255, 0, 0], bold: true });
+    expect(n.color).toEqual([255, 0, 0]);
+    expect(n.bold).toBe(true);
+  });
+
+  it("text() object shape: `fg` with a SemanticColor string", () => {
+    const n = text("hi", { fg: "primary", italic: true });
+    expect(n.color).toBe("primary");
+    expect(n.italic).toBe(true);
+  });
+
+  it("text() object shape without `fg` leaves color unset", () => {
+    const n = text("hi", { bold: true, dim: true });
+    expect(n.color).toBeUndefined();
+    expect(n.bold).toBe(true);
+    expect(n.dim).toBe(true);
+  });
+
+  it("text() with no args after str", () => {
+    const n = text("hi");
+    expect(n.type).toBe("text");
+    expect(n.text).toBe("hi");
+    expect(n.color).toBeUndefined();
+    expect(n.bold).toBeUndefined();
+  });
+
   it("spacer, gap, separator, indent", () => {
     expect(spacer().type).toBe("spacer");
     expect(gap(3).size).toBe(3);


### PR DESCRIPTION
Fixes the demo-blocking issue cos routed in `1783414289698-rthqrt.md`.

## Finding (important: framing correction)

Cos's brief described `dist/tui` as **stale vs `src/tui`**. Investigation shows:

- The published `@myobie/pty@0.10.0` `dist/tui/builders.d.ts` and `builders.js` are byte-for-byte consistent with the current `src/tui/builders.ts` for both `text` and `column`. Nothing in dist is stale.
- Consumer files in `/Volumes/SSD/src/eval-sandbox/st-evals/cells/tui-build/fixture/seed-protos/` use `text(str, { fg: color, ... })` — an **object form that pty's `text()` has never accepted at any version**. `text()` was always `text(str, color?, opts?)` positional; the seed-protos are calling a shape that doesn't exist.
- `column({ props }, children)` matches the current API on both sides — no gap there.

So "dist stale" was the wrong diagnosis. The right fix, given the consumer is already the shape it is and the demo is imminent, is to **teach `text()` to accept the object form** rather than churn every call site.

## Fix

`text()` gains a second calling shape:

```ts
text("hi");                              // no args after str
text("hi", someColor);                   // positional Color
text("hi", someColor, { bold: true });   // positional Color + opts
text("hi", { fg: someColor, bold: true });  // object form; NEW
```

Dispatch is by second-arg TYPE, not arity:

- `string` (SemanticColor) or array (`[r,g,b]`) → treat as `color` (positional shape, unchanged).
- Plain object → treat as `TextOpts & { fg?: Color }`; `fg` maps to `color`, everything else spreads into the node.

Both shapes produce identical `TextNode`s.

## Version bump 0.10.0 → 0.11.0

The overload itself is additive (non-breaking) but everything else queued since the last publish IS breaking, so 0.11.0 signals "revisit before upgrading":

- Removed `pty state` (CLI + `@myobie/pty/client` exports + events + metadata field).
- Removed `pty wrap` / `unwrap` (+ `PTY_BIN_PATH`).
- Supervisor + launchd wrapper replaced by cron-driven `pty gc`.
- Name/displayName decouple (id vs label).
- `PTY_ROOT` canonical env; `PTY_SESSION_DIR` legacy alias.
- `session_flapping` event + fast-fail respawn cap.
- Per-network gc plist Label/logPath parametrization.

Detailed CHANGELOG entry under `## 0.11.0`.

## Publish step

I can't publish from here (`npm whoami` returns 401). **Nathan needs to run `npm publish` after this PR lands.** The demo dependency chain:

1. Merge this PR.
2. Nathan runs `npm publish` from a fresh checkout of main.
3. I ping evals-claude with "0.11.0 is on npm; the eval consumers' `text(str, {fg, ...})` shape now composes".

## Test plan

- [x] `tests/tui-framework.test.ts` (5 new): object shape with `fg` + `bold`; `fg` = SemanticColor string; object without `fg`; no args after str; existing positional cases untouched.
- [x] Full suite: **1206 passed, 21 skipped, 0 failed**.
- [x] `flake.nix` npmDepsHash refreshed after `npm install` (required by pre-commit hook).