### PR TITLE
fix(restart): preserve displayName across respawn

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -1186,9 +1186,13 @@ async function handleDeadSession(
     }
   }
 
-  // Restart
+  // Restart. Preserve displayName (and tags) so the respawned session keeps its
+  // name instead of falling back to the raw id.
   cleanupAll(session.name);
-  await spawnDaemon({ name: session.name, command: meta.command, args: meta.args, displayCommand: meta.displayCommand, cwd: meta.cwd, tags: meta.tags });
+  await spawnDaemon({
+    name: session.name, command: meta.command, args: meta.args, displayCommand: meta.displayCommand, cwd: meta.cwd, tags: meta.tags,
+    ...(meta.displayName ? { displayName: meta.displayName } : {}),
+  });
   console.log(`Session "${session.name}" restarted.`);
   doAttach(session.name);
 }
@@ -2751,7 +2755,13 @@ async function cmdRestart(
   // command edit already clears these; this handles the operator-
   // intervenes-without-edit case that gc otherwise can't infer.
   const restartTags = clearFlappingBookkeeping(meta.tags);
-  await spawnDaemon({ name, command: meta.command, args: meta.args, displayCommand: meta.displayCommand, cwd: meta.cwd, tags: restartTags });
+  // Preserve the human-friendly displayName across the respawn — without it the
+  // restarted session reads as its raw id (e.g. claude-203827) instead of its
+  // name, which breaks naming + the TUI peek. Tags are carried above.
+  await spawnDaemon({
+    name, command: meta.command, args: meta.args, displayCommand: meta.displayCommand, cwd: meta.cwd, tags: restartTags,
+    ...(meta.displayName ? { displayName: meta.displayName } : {}),
+  });
   console.log(`Session "${name}" restarted.`);
 
   // Nesting guard: restart itself is fine, but attaching would nest a client

--- a/src/tui/interactive.ts
+++ b/src/tui/interactive.ts
@@ -503,7 +503,12 @@ async function doRestart(session: SessionInfo): Promise<void> {
   }
   cleanupAll(session.name);
   try {
-    await spawnDaemon({ name: session.name, command: meta.command, args: meta.args, displayCommand: meta.displayCommand, cwd: meta.cwd, tags: meta.tags });
+    // Preserve displayName (and tags) so a restarted session keeps its name
+    // rather than reverting to its raw id.
+    await spawnDaemon({
+      name: session.name, command: meta.command, args: meta.args, displayCommand: meta.displayCommand, cwd: meta.cwd, tags: meta.tags,
+      ...(meta.displayName ? { displayName: meta.displayName } : {}),
+    });
   } catch {
     // Refresh list to show updated state
     const updated = await listSessions();

--- a/tests/display-name.test.ts
+++ b/tests/display-name.test.ts
@@ -360,3 +360,37 @@ describe("commands resolve a long displayName even when it would fail validateNa
     expect(running).toHaveLength(0);
   });
 });
+
+describe("pty restart preserves displayName + tags", () => {
+  // Regression: `pty restart` re-spawned the daemon from stored metadata but
+  // dropped `displayName`, so a restarted session read as its raw id (e.g.
+  // claude-203827) instead of its name — breaking naming and the TUI peek.
+  // Tags were already carried; this locks in both.
+  it("keeps displayName and tags across a restart", () => {
+    const dir = makeSessionDir();
+    const create = runCli(
+      dir, {},
+      "run", "-d", "--id", "svc", "--name", "My Service", "--tag", "role=web", "--", "cat",
+    );
+    expect(create.status).toBe(0);
+
+    let s = listJson(dir).find((x: any) => x.name === "svc")!;
+    expect(s).toBeDefined();
+    expect(s.displayName).toBe("My Service");
+    expect(s.tags?.role).toBe("web");
+    collectPid(dir, "svc");
+
+    // Restart. Setting PTY_SESSION makes the CLI take the "already inside a
+    // session, not attaching" branch and return, instead of hanging on attach
+    // in this non-TTY test process.
+    const restart = runCli(dir, { PTY_SESSION: "outer" }, "restart", "-y", "svc");
+    expect(restart.status).toBe(0);
+    expect(restart.stdout).toContain("restarted");
+
+    s = listJson(dir).find((x: any) => x.name === "svc")!;
+    expect(s).toBeDefined();
+    expect(s.displayName).toBe("My Service");
+    expect(s.tags?.role).toBe("web");
+    collectPid(dir, "svc");
+  });
+});


### PR DESCRIPTION
## Problem

`pty restart` (and the other restart paths) re-spawned the session daemon from stored metadata but **dropped `displayName`**. A restarted session came back reading as its raw id (e.g. `claude-203827`) instead of its name — breaking session naming and the TUI peek. Tags were already preserved; only the display name was lost.

## Fix

Forward `meta.displayName` at all three restart call sites, matching the existing `run -a` re-create path (`cli.ts` ~L1048):

- `cmdRestart` — `pty restart <ref>`
- `handleDeadSession` — `pty attach -r` / restart-on-dead prompt
- interactive `doRestart` — Enter on a dead session in the picker

Each uses the same guarded spread: `...(meta.displayName ? { displayName: meta.displayName } : {})`.

## Test

Adds a driven regression test in `tests/display-name.test.ts` that creates a session with `--name "My Service" --tag role=web`, restarts it, and asserts both `displayName` and tags survive. Verified it **fails without the fix** (`expected undefined to be 'My Service'`) and passes with it.

- `display-name` suite: 27/27 green
- `tui` suite: 29/29 green
- Manual end-to-end: `restart` of `id=web1 name='Web Frontend' tag role=web` keeps both name and tags, status back to running.

## Notes

Independent bugfix targeting `main` (the bug is present on both `main` and the held reboot `#60` branch). Can be cherry-picked into the reboot cutover as needed.
