### PR TITLE
test: scrub ambient PTY_ROOT so the suite is hermetic inside a pty session

### DIFF
--- a/src/testing/session.ts
+++ b/src/testing/session.ts
@@ -26,6 +26,38 @@ function autoName(): string {
   return `test-${process.pid}-${Date.now()}-${++nameCounter}`;
 }
 
+/**
+ * Build the environment for a spawned `pty` process: the caller's base env
+ * merged with `optsEnv`, minus the harness's own pty-internal context.
+ *
+ * Two hazards this guards against when the test harness ITSELF runs inside a
+ * pty session:
+ *   - PTY_SESSION / PTY_SERVER_CONFIG leaking in would trip the spawned CLI's
+ *     nesting-prevention guard (or hand it a bogus server config). Always
+ *     scrubbed.
+ *   - PTY_ROOT / PTY_SESSION_DIR leaking in would override the caller's
+ *     intended isolation, because getSessionDir() prefers ambient PTY_ROOT over
+ *     the per-call PTY_SESSION_DIR — so the spawned `pty` would read the real
+ *     live session dir. Scrubbed ONLY when the caller didn't set them
+ *     explicitly via `optsEnv`, so a deliberate root override still wins.
+ *
+ * Pure and exported for unit testing.
+ */
+export function buildSpawnEnv(
+  base: Record<string, string | undefined>,
+  optsEnv?: Record<string, string>,
+): Record<string, string> {
+  const env: Record<string, string> = {
+    ...(base as Record<string, string>),
+    ...optsEnv,
+  };
+  delete env.PTY_SERVER_CONFIG;
+  delete env.PTY_SESSION;
+  if (optsEnv?.PTY_ROOT === undefined) delete env.PTY_ROOT;
+  if (optsEnv?.PTY_SESSION_DIR === undefined) delete env.PTY_SESSION_DIR;
+  return env;
+}
+
 export class Session {
   private terminal: Terminal;
   private serialize: SerializeAddon;
@@ -77,16 +109,7 @@ export class Session {
     const serialize = new xtermSerialize.SerializeAddon();
     terminal.loadAddon(serialize);
 
-    const env: Record<string, string> = {
-      ...(process.env as Record<string, string>),
-      ...opts.env,
-    };
-    // Scrub pty-internal env vars so the spawned CLI sees a clean user
-    // environment, not the test harness's own pty context. Without this,
-    // any test that runs `pty` inside a Session inherits the harness's
-    // PTY_SESSION and trips the nesting-prevention guard.
-    delete env.PTY_SERVER_CONFIG;
-    delete env.PTY_SESSION;
+    const env = buildSpawnEnv(process.env as Record<string, string | undefined>, opts.env);
 
     const proc = pty.spawn(command, args, {
       name: "xterm-256color",

--- a/tests/env-isolation.test.ts
+++ b/tests/env-isolation.test.ts
@@ -1,0 +1,58 @@
+import { describe, it, expect } from "vitest";
+import { buildSpawnEnv } from "../src/testing/session.ts";
+
+// Regression coverage for the test-isolation gap: when the harness itself runs
+// inside a pty session, ambient PTY_ROOT (which getSessionDir() prefers over
+// PTY_SESSION_DIR) leaked into spawned `pty`s and made them read the real live
+// session dir instead of the per-test tmpdir.
+
+describe("buildSpawnEnv (Session.spawn env isolation)", () => {
+  it("always scrubs PTY_SESSION and PTY_SERVER_CONFIG", () => {
+    const env = buildSpawnEnv({ PTY_SESSION: "silber.pty", PTY_SERVER_CONFIG: "{}", HOME: "/h" });
+    expect(env.PTY_SESSION).toBeUndefined();
+    expect(env.PTY_SERVER_CONFIG).toBeUndefined();
+    expect(env.HOME).toBe("/h"); // unrelated vars pass through
+  });
+
+  it("scrubs ambient PTY_ROOT / PTY_SESSION_DIR when the caller didn't set them", () => {
+    const env = buildSpawnEnv({ PTY_ROOT: "/real/root", PTY_SESSION_DIR: "/real/dir" });
+    expect(env.PTY_ROOT).toBeUndefined();
+    expect(env.PTY_SESSION_DIR).toBeUndefined();
+  });
+
+  it("does NOT let ambient PTY_ROOT override an explicit per-call PTY_SESSION_DIR", () => {
+    // The core failure mode: caller isolates via PTY_SESSION_DIR, harness has an
+    // ambient PTY_ROOT. The child must see PTY_SESSION_DIR and no PTY_ROOT, so
+    // getSessionDir() resolves to the caller's dir.
+    const env = buildSpawnEnv(
+      { PTY_ROOT: "/real/root", HOME: "/h" },
+      { PTY_SESSION_DIR: "/tmp/isolated" },
+    );
+    expect(env.PTY_ROOT).toBeUndefined();
+    expect(env.PTY_SESSION_DIR).toBe("/tmp/isolated");
+  });
+
+  it("keeps a PTY_ROOT the caller set explicitly (deliberate override wins)", () => {
+    const env = buildSpawnEnv(
+      { PTY_ROOT: "/ambient/root" },
+      { PTY_ROOT: "/wanted/root" },
+    );
+    expect(env.PTY_ROOT).toBe("/wanted/root");
+  });
+
+  it("keeps a PTY_SESSION_DIR the caller set explicitly", () => {
+    const env = buildSpawnEnv({}, { PTY_SESSION_DIR: "/wanted/dir" });
+    expect(env.PTY_SESSION_DIR).toBe("/wanted/dir");
+  });
+});
+
+describe("isolation hard guard (tests/setup/isolate-env.ts)", () => {
+  it("has scrubbed ambient PTY_ROOT / PTY_SESSION / PTY_SESSION_DIR from the worker", () => {
+    // The setupFile runs once per worker before any test module. If this fails,
+    // the suite is running with a leaked ambient pty context and any test that
+    // spawns `pty` may read the developer's real live session dir.
+    expect(process.env.PTY_ROOT).toBeUndefined();
+    expect(process.env.PTY_SESSION).toBeUndefined();
+    expect(process.env.PTY_SESSION_DIR).toBeUndefined();
+  });
+});

--- a/tests/gc-flap-clear-badge-root-len.test.ts
+++ b/tests/gc-flap-clear-badge-root-len.test.ts
@@ -88,8 +88,16 @@ describe("pty restart clears strategy.status=flapping + bookkeeping", () => {
 
     // Restart it. -y skips the prompt; command is "sh -c 'exit 1'" which
     // will exit almost immediately — that's fine, we care about the tag
-    // snapshot right after spawn.
-    const r = runCli(dir, "restart", "-y", name);
+    // snapshot right after spawn. PTY_SESSION is set so restart takes its
+    // "already inside a session, don't attach" branch and returns 0 instead of
+    // attaching to the just-exited session (a non-TTY attach here would inherit
+    // that session's exit code 1). Setting it explicitly rather than relying on
+    // an ambient PTY_SESSION leaking from the harness.
+    const r = spawnSync(nodeBin, [cliPath, "restart", "-y", name], {
+      env: { ...process.env, PTY_SESSION_DIR: dir, PTY_SESSION: "outer" },
+      encoding: "utf-8",
+      timeout: 15000,
+    });
     expect(r.status).toBe(0);
 
     // Give the daemon a moment to write its metadata.

--- a/tests/setup/isolate-env.ts
+++ b/tests/setup/isolate-env.ts
@@ -1,0 +1,21 @@
+// Per-worker isolation hard guard.
+//
+// The vitest process may itself be running INSIDE a pty session (this repo is
+// often developed/tested from within a `pty` session), which means the ambient
+// environment carries PTY_ROOT / PTY_SESSION / PTY_SESSION_DIR. Tests isolate by
+// passing a per-test PTY_SESSION_DIR to each spawned `pty`, but getSessionDir()
+// prefers PTY_ROOT over PTY_SESSION_DIR — so an ambient PTY_ROOT (inherited via
+// `{ ...process.env }` in the test helpers) silently WINS and every spawned
+// `pty` reads the developer's REAL live session dir instead of the tmpdir. That
+// turns the suite non-deterministic and can even mutate live sessions.
+//
+// This file is registered as a vitest `setupFiles` entry, so it runs once in
+// every worker BEFORE any test module executes. Scrubbing here guarantees that
+// neither the worker nor any child it spawns (Session.spawn, raw spawn/spawnSync
+// in the test helpers) inherits the ambient pty context. Tests that WANT a
+// specific root still pass it explicitly per-child via `opts.env` /
+// `PTY_SESSION_DIR`, which is unaffected — we only clear the process-level
+// ambient values.
+delete process.env.PTY_ROOT;
+delete process.env.PTY_SESSION;
+delete process.env.PTY_SESSION_DIR;

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -6,5 +6,9 @@ export default defineConfig({
       "node_modules/**",
     ],
     globalSetup: ["./tests/setup/vitest-global.ts"],
+    // Runs once per worker before any test module — scrubs ambient
+    // PTY_ROOT/PTY_SESSION/PTY_SESSION_DIR so a suite launched from inside a
+    // pty session can't leak the real live session dir into spawned `pty`s.
+    setupFiles: ["./tests/setup/isolate-env.ts"],
   },
 });


### PR DESCRIPTION
## Problem

When the vitest process itself runs **inside a pty session** (this repo is often developed/tested from within `pty`), its ambient `PTY_ROOT` / `PTY_SESSION` / `PTY_SESSION_DIR` leaked into every spawned `pty`. `getSessionDir()` prefers `PTY_ROOT` over the per-test `PTY_SESSION_DIR` the helpers pass — so the spawned CLI read the developer's **real live session dir** instead of the test tmpdir. Result: non-deterministic failures (the interactive picker showed real sessions), and a risk of mutating live sessions. `Session.spawn` scrubbed `PTY_SESSION` but not `PTY_ROOT`, and nothing scrubbed it at the harness level.

## Fix

- **`tests/setup/isolate-env.ts`** — new per-worker `setupFiles` entry (registered in `vitest.config.ts`) that scrubs the three ambient vars before any test module runs. The hard guard.
- **`Session.spawn`** — extracted `buildSpawnEnv()` (pure, exported) and also scrub ambient `PTY_ROOT` / `PTY_SESSION_DIR` there, so external users of the shipped `@myobie/pty/testing` library get the same isolation. Guarded: a root the caller sets explicitly via `opts.env` still wins.
- **`tests/env-isolation.test.ts`** — unit tests for `buildSpawnEnv` (scrub-vs-keep matrix) + a guard test asserting the setupFile scrubbed the worker env.
- **`gc-flap-clear-badge-root-len`** — the restart test was green only because an ambient `PTY_SESSION` made `pty restart` skip its attach; it now sets `PTY_SESSION` explicitly so it doesn't depend on the leak. (Surfaced by this fix — same isolation class.)

## Verification

- **Full suite green (1213 passed, 21 skipped) WITH ambient `PTY_ROOT` set and no `env -u` / shim workarounds** — i.e. hermetic when run from inside a pty session, which it was not before.
- No change in clean CI: with no ambient pty vars the scrub is a no-op.

## Note / possible follow-up

The interactive-picker tests still shell out to the real `pty-relay` if it's installed (host discovery is independent of `PTY_ROOT`). On this machine it returns a single unreachable/errored host with no sessions, so it's benign and tests are green — but a dev with reachable relay hosts could in theory see remote entries. A `pty-relay`-discovery disable hook would make the picker tests fully hermetic; out of scope here, flagging for a possible separate pass.
