### PR TITLE
docs: fix stale client API + development docs (onboarding audit)

### DIFF
--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -5,7 +5,7 @@ A persistent terminal session manager. Run long-lived processes, detach, reconne
 ## Objectives
 
 - Replace tmux/zellij for **session persistence** of long-running processes
-- Simple CLI: `pty run <name> <command>`, `pty attach <name>`, `pty peek <name>`, `pty restart <name>`
+- Simple CLI: `pty run -- <command>`, `pty attach <name>`, `pty peek <name>`, `pty restart <name>`
 - Reliable detach/reattach with full screen replay (colors, cursor position, scrollback)
 - Work seamlessly over SSH (Unix sockets, no port management)
 - Multi-client support (multiple people can observe or interact with a session)
@@ -26,24 +26,24 @@ npm test               # run all tests once
 npm run test:watch     # run tests in watch mode
 npm run verify-docs    # run executable examples in docs/testing.md
 
-# Usage (during development)
-npx tsx src/cli.ts run <name> -- <command> [args...]
-npx tsx src/cli.ts run -d <name> -- <command> [args...]
-npx tsx src/cli.ts attach <name>
-npx tsx src/cli.ts peek <name>
-npx tsx src/cli.ts peek -f <name>
-npx tsx src/cli.ts list
-npx tsx src/cli.ts restart <name>
-npx tsx src/cli.ts kill <name>
-npx tsx src/cli.ts test                  # run tests via vitest
-npx tsx src/cli.ts test -t "pattern"     # run matching tests
+# Usage (during development — run the TS source directly with Node)
+node --experimental-strip-types src/cli.ts run -- <command> [args...]
+node --experimental-strip-types src/cli.ts run -d -- <command> [args...]
+node --experimental-strip-types src/cli.ts attach <name>
+node --experimental-strip-types src/cli.ts peek <name>
+node --experimental-strip-types src/cli.ts peek -f <name>
+node --experimental-strip-types src/cli.ts list
+node --experimental-strip-types src/cli.ts restart <name>
+node --experimental-strip-types src/cli.ts kill <name>
+node --experimental-strip-types src/cli.ts test                  # run tests via vitest
+node --experimental-strip-types src/cli.ts test -t "pattern"     # run matching tests
 ```
 
 Detach from any attached/following session with **Ctrl+\\**. Press Ctrl+\\ twice quickly to send it to the process.
 
-### No build step
+### Build
 
-This project ships TypeScript source directly — there is no compile step. All `.ts` files use `.ts` import extensions and are executed at runtime by [tsx](https://tsx.is). The `bin/pty` entry point locates tsx from `node_modules` and runs `src/cli.ts`. The `tsc` command is used only for typechecking (`noEmit: true`).
+Source is written in TypeScript with `.ts` import extensions. `npm run build` compiles `src/` to `dist/` via `tsc -p tsconfig.build.json` (`rewriteRelativeImportExtensions` turns the `.ts` import specifiers into `.js` in the output), and the published package ships `dist/`. The `bin/pty` entry point runs the compiled `dist/cli.js` with Node — so run `npm run build` before invoking the installed `pty`. During development you can skip the build and run the source directly with Node's native type stripping: `node --experimental-strip-types src/cli.ts …`. The separate `tsconfig.json` (`noEmit: true`, `allowImportingTsExtensions: true`) backs `npm run typecheck` only.
 
 ## Architecture
 
@@ -70,7 +70,7 @@ This project ships TypeScript source directly — there is no compile step. All 
      (attach)   (attach)     (read-only)
 ```
 
-Each session is a detached Node.js process running `src/server.ts` via tsx. It spawns the command in a PTY, feeds all output through xterm-headless to maintain a screen buffer, and listens on a Unix socket for client connections.
+Each session is a detached Node.js process running the compiled `server.js` with Node. It spawns the command in a PTY, feeds all output through xterm-headless to maintain a screen buffer, and listens on a Unix socket for client connections.
 
 ## Protocol
 
@@ -90,13 +90,13 @@ Binary packets over Unix sockets: `[type: uint8][length: uint32BE][payload]`
 
 ## Key Design Decisions
 
-### No build step — ship TypeScript directly
+### Compile to `dist/`, keep `.ts` sources runnable
 
-There is no `dist/` directory. Source files use `.ts` import extensions and run directly via tsx. The `tsconfig.json` has `noEmit: true` and `allowImportingTsExtensions: true` — tsc is only used for typechecking. This eliminates the compile-then-run dance entirely. tsx is a regular dependency (not devDependency) because it's needed at runtime.
+The published package ships compiled JavaScript in `dist/` (`tsc -p tsconfig.build.json`, with `rewriteRelativeImportExtensions` rewriting `.ts` imports to `.js`), so an install never depends on a TypeScript runtime or Node's still-experimental type stripping. Sources keep `.ts` import extensions, so during development they also run directly under `node --experimental-strip-types` with no build. `tsconfig.json` (`noEmit: true`, `allowImportingTsExtensions: true`) is typecheck-only.
 
 ### No TypeScript enums
 
-We avoid TS enums because they emit runtime code that can't be type-stripped. Instead, we use `as const` objects with a derived union type. This is compatible with all TS runtimes: Node's native type stripping, tsx, esbuild, swc.
+We avoid TS enums because they emit runtime code that can't be type-stripped. Instead, we use `as const` objects with a derived union type. This keeps the sources runnable under Node's native type stripping (and any other type-stripper) without a build.
 
 ### Peek clients don't affect terminal size
 
@@ -116,7 +116,7 @@ Each session is an independent Node.js process. No central daemon, no shared sta
 
 ### Unix sockets for local IPC
 
-Fast, zero-config, and work transparently over SSH. No ports to manage, no firewall rules. Session sockets live at `~/.local/state/pty/<name>.sock` (override with `$PTY_SESSION_DIR`).
+Fast, zero-config, and work transparently over SSH. No ports to manage, no firewall rules. Session sockets live at `~/.local/state/pty/<name>.sock` (override the root with `$PTY_ROOT`).
 
 ### PtyServer never calls process.exit()
 
@@ -210,7 +210,7 @@ completions/
   pty.bash        Bash tab completion
   pty.zsh         Zsh tab completion
 bin/
-  pty             Entry point (locates tsx, runs src/cli.ts)
+  pty             Entry point (runs dist/cli.js with Node)
 ```
 
 ## Future

--- a/docs/client.md
+++ b/docs/client.md
@@ -25,22 +25,34 @@ Throws if the name is invalid. Names must match `[a-zA-Z0-9._-]` and be at most 
 
 ### `getSessionDir(): string`
 
-Returns the session directory path (`PTY_SESSION_DIR` env var or `~/.local/state/pty`).
+Returns the session directory path — `$PTY_ROOT` if set (the legacy `$PTY_SESSION_DIR` name is still honored), otherwise `~/.local/state/pty`.
 
 ### `getSocketPath(name: string): string`
 
 Returns the Unix socket path for a session.
 
-### `gc(opts?: { dryRun?: boolean }): Promise<string[]>`
+### `gc(opts?: { dryRun?: boolean; idleDays?: number; fastFailWindowSec?: number; fastFailLimit?: number }): Promise<GcResult>`
 
-Remove all exited **and** vanished sessions. Returns the names of removed sessions. Pass `{ dryRun: true }` to walk the same set without deleting anything — useful for preview UIs.
+Run one reconciliation pass: remove exited/vanished non-permanent sessions, kill orphaned `parent=` children, reap abandoned permanents, and respawn (or flap-skip) `strategy=permanent` sessions. Returns a `GcResult` describing everything the pass did. Pass `{ dryRun: true }` to compute the same plan without mutating anything — useful for preview UIs.
 
 ```typescript
-const removed = await gc();
-console.log(`Cleaned up ${removed.length} sessions`);
+const result = await gc();
+console.log(`Removed ${result.removed.length}, respawned ${result.respawned.length}`);
 
-const would = await gc({ dryRun: true });
-console.log(`Would clean up: ${would.join(", ")}`);
+const plan = await gc({ dryRun: true });
+console.log(`Would remove: ${plan.removed.join(", ")}`);
+```
+
+```typescript
+interface GcResult {
+  removed: string[];                                                              // exited/vanished non-permanent sessions cleaned up
+  killedOrphanChildren: { name: string; parent: string; reason: "missing" | "dead" }[];
+  abandoned: { name: string; reason: "cwd-gone" | "idle"; idleDays?: number }[];  // live permanents reaped as abandoned
+  respawned: { name: string; ptyfileReread: boolean }[];
+  respawnFailed: { name: string; error: string }[];
+  flapped: { name: string; counter: number; limit: number; window: number }[];    // flipped to strategy.status=flapping this tick
+  flappingSkipped: string[];                                                       // already-flapping, skipped this tick
+}
 ```
 
 ### `isGone(status): boolean`
@@ -60,7 +72,7 @@ interface PrunedTagResult {
 
 ### `isReservedTagKey(key: string): boolean`
 
-Returns `true` for pty's internal bookkeeping keys (`ptyfile`, `ptyfile.session`, `ptyfile.tags`, `supervisor.status`, `strategy`) and for any key starting with `:` (the tool-owned-tag convention). Downstream tools should hide reserved keys from user-facing listings by default but still allow writes — set and unset them as needed.
+Returns `true` for pty's internal bookkeeping keys (`ptyfile`, `ptyfile.session`, `ptyfile.tags`, `strategy`) and for any key starting with `:` (the tool-owned-tag convention). Downstream tools should hide reserved keys from user-facing listings by default but still allow writes — set and unset them as needed.
 
 ### `cleanupSocket(name: string): void`
 


### PR DESCRIPTION
## Onboarding doc audit

Audited the README + every tracked repo doc (`README.md`, `CHANGELOG.md`, `DEVELOPMENT.md`, `docs/client.md`, `docs/disk-layout.md`, `docs/SKILL.md`, `docs/testing.md`) against the code on `main`, ahead of opening to new users. Bar: zero mistakes.

**Two files had factual errors; fixed here. The rest verified accurate.**

### `docs/client.md`
- **`gc()` return type was wrong** — documented as `Promise<string[]>` (removed names); it actually returns a `GcResult` object. Fixed the signature + example and added the `GcResult` shape.
- **`getSessionDir()`** described only `PTY_SESSION_DIR`; it prefers the canonical `PTY_ROOT` (legacy name still honored).
- **`isReservedTagKey()`** listed `supervisor.status`, no longer a reserved key (`EXACT_RESERVED` is `ptyfile`, `ptyfile.session`, `ptyfile.tags`, `strategy`). Removed it.

### `DEVELOPMENT.md`
- **Architecture was stale**: said "ships TypeScript directly, no build step, run via tsx". Actually `tsx` isn't a dependency, `npm run build` compiles `src/` → `dist/` (`rewriteRelativeImportExtensions`), the package ships `dist/`, and `bin/pty` runs `dist/cli.js` with Node. Rewrote the Build section, the design-decision note, the architecture line, and the `bin/pty` file-structure entry. Dev-usage examples now use `node --experimental-strip-types src/cli.ts` (verified it runs).
- `pty run <name> <command>` → `pty run -- <command>` (actual syntax).
- Socket override `$PTY_SESSION_DIR` → canonical `$PTY_ROOT`.

### Verified accurate (no changes)
- **README**: commands, flags (`--with-delay`, repeatable `--wait`, `-e`, emit arg order), `demos/` (all four apps + `run` exist), event types (`session_flapping` real), fast-fail defaults (60s/3), default `$PTY_ROOT`, client-API symbol list, subpath exports.
- **CHANGELOG**: historical record — left as-is.
- **disk-layout / SKILL / testing**: event-type table, reserved keys, strategy tags all match code; `docs/testing.md` executable examples pass via `npm run verify-docs` (13/13).

### Org move & stale ecosystem commands
- **No changes needed.** No `st launch` / `coord*` / `convoy.toml` in the docs. The only `myobie/` URLs are `myobie/pty` and `myobie/pty-relay` — both stay `myobie`. Moved repos (convoy/evals/smalltalk) appear only as prose names, not clickable `myobie/` URLs.
