### PR TITLE
test: fix 6 pre-existing typecheck errors so `npm run typecheck` is clean

### DIFF
--- a/tests/exec.test.ts
+++ b/tests/exec.test.ts
@@ -109,7 +109,7 @@ describe("pty exec", () => {
 
   it("errors when not inside a pty session", () => {
     const dir = makeSessionDir();
-    const env = { ...process.env, PTY_SESSION_DIR: dir };
+    const env: Record<string, string | undefined> = { ...process.env, PTY_SESSION_DIR: dir };
     delete env.PTY_SESSION;
 
     const result = spawnSync(nodeBin, [cliPath, "exec", "--", "echo", "hi"], {

--- a/tests/nesting.test.ts
+++ b/tests/nesting.test.ts
@@ -191,7 +191,7 @@ describe("pty nesting prevention", () => {
     const name = uniqueName();
 
     // Remove PTY_SESSION from env explicitly
-    const env = { ...process.env, PTY_SESSION_DIR: dir };
+    const env: Record<string, string | undefined> = { ...process.env, PTY_SESSION_DIR: dir };
     delete env.PTY_SESSION;
 
     const result = spawnSync(nodeBin, [cliPath, "run", "-d", "--id", name, "--", "cat"], {

--- a/tests/tui-framework.test.ts
+++ b/tests/tui-framework.test.ts
@@ -7,7 +7,7 @@ import {
   groupedSelectable, statusBar, footer, askBar, textInput, fpsCounter,
   canvas, screen, overlay,
   layoutRoot, layoutVertical, layoutRow, textWidth,
-  renderToAnsi, resolveColor,
+  renderToAnsi, resolveColor, createFocusManager,
   type UINode, type RenderOpts,
 } from "../src/tui/index.ts";
 import { CellBuffer } from "../src/tui/buffer.ts";
@@ -509,6 +509,7 @@ describe("text wrap", () => {
       navigate: () => {}, back: () => {},
       openOverlay: () => {}, closeOverlay: () => {},
       isTextInputActive: () => false, setTextInputActive: () => {},
+      quit: () => {}, focus: createFocusManager(),
     };
     const buf = myScreen.renderToBuffer(ctx);
     const line0 = buf.cells[0].map(c => c.char).join("").trim();
@@ -549,6 +550,7 @@ describe("text highlight", () => {
       navigate: () => {}, back: () => {},
       openOverlay: () => {}, closeOverlay: () => {},
       isTextInputActive: () => false, setTextInputActive: () => {},
+      quit: () => {}, focus: createFocusManager(),
     };
     const buf = myScreen.renderToBuffer(ctx);
     // "Hello" (chars 0-4) should be bold + accent color
@@ -578,6 +580,7 @@ describe("text highlight", () => {
       navigate: () => {}, back: () => {},
       openOverlay: () => {}, closeOverlay: () => {},
       isTextInputActive: () => false, setTextInputActive: () => {},
+      quit: () => {}, focus: createFocusManager(),
     };
     const buf = myScreen.renderToBuffer(ctx);
     // Word-wrap: "AAA" / " BBB" / " CCC" (breaks before spaces)
@@ -612,6 +615,7 @@ describe("text highlight", () => {
       navigate: () => {}, back: () => {},
       openOverlay: () => {}, closeOverlay: () => {},
       isTextInputActive: () => false, setTextInputActive: () => {},
+      quit: () => {}, focus: createFocusManager(),
     };
     const buf = myScreen.renderToBuffer(ctx);
     expect(buf.cells[0][0].bold).toBe(true);


### PR DESCRIPTION
## Problem

`npm run typecheck` (tsc over `src` + `tests`) was red on `main` with **6 errors**, all in test files. The vitest suite passes (it strips types at runtime), and `nix build` / `npm run build` are src-only, so **CI (`nix.yml` runs only `nix build`) never caught them** and they accumulated. A fresh cloner running `npm run typecheck` hits all 6.

## Fixes (test-only)

- **`tests/tui-framework.test.ts` (×4)** — the `ScreenContext` render mocks predate the focus-manager work and were missing the now-required `quit` and `focus` fields. Completed each mock (`quit` no-op + `createFocusManager()`).
- **`tests/exec.test.ts`, `tests/nesting.test.ts`** — `{ ...process.env, PTY_SESSION_DIR }` drops the index signature, so `delete env.PTY_SESSION` failed to typecheck. Annotated `env` as `Record<string, string | undefined>` — the same pattern the other test helpers already use.

## Verification

- `npm run typecheck` → **0 errors** (was 6).
- The 3 touched files pass at runtime: **95 tests green**.
- No src changes; shipped artifact unaffected.

## Related recommendation (not in this PR)

CI (`nix.yml`) only runs `nix build`. Adding `npm run typecheck` + `npx vitest run` to CI would stop this class of regression from landing unseen. Flagging for a separate call.
