### PR TITLE
chore: point remaining repo URLs at compoundingtech org

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -69,7 +69,7 @@
 
             meta = with pkgs.lib; {
               description = "Persistent terminal sessions with detach/attach support";
-              homepage = "https://github.com/myobie/pty";
+              homepage = "https://github.com/compoundingtech/pty";
               license = licenses.mit;
               mainProgram = "pty";
             };

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "license": "MIT",
   "repository": {
     "type": "git",
-    "url": "https://github.com/myobie/pty.git"
+    "url": "https://github.com/compoundingtech/pty.git"
   },
   "keywords": [
     "terminal",

--- a/tests/list-filters.test.ts
+++ b/tests/list-filters.test.ts
@@ -156,7 +156,7 @@ describe("vanished status", () => {
 });
 
 describe("listSessions guards against deleting state for live daemons", () => {
-  // Refs https://github.com/myobie/pty/issues/34. listSessions used to
+  // Refs https://github.com/compoundingtech/pty/issues/34. listSessions used to
   // unconditionally `cleanupSocket` whenever the socket-reachable probe
   // failed and `cleanupAll` whenever metadata was older than 24h. Both
   // ran even if the recorded pid was still alive — once the .sock or


### PR DESCRIPTION
## Fresh-clone sweep: remaining repo URLs → compoundingtech

Follow-up to the org move — the accurate fresh-clone sweep found repo URLs still on the old org:

- **`package.json`** `repository.url` → `https://github.com/compoundingtech/pty.git`
- **`flake.nix`** `meta.homepage` → `https://github.com/compoundingtech/pty`
- **`tests/list-filters.test.ts`** issue-ref comment → `compoundingtech/pty/issues/34` (historical ref; updated for consistency)

After this, **zero `github.com/myobie` repo URLs remain** anywhere in the tree.

**Intentionally kept** (not repo URLs): the `@myobie/pty` npm package scope (the package is still published under that name — `package.json` `"name"` is `@myobie/pty`), and the `com.myobie.pty.*` launchd Labels (reverse-DNS ids, backwards-compatible with existing installs).

`package.json` still parses; no code touched.
