### PR TITLE
feat(cli): add `pty --version` / `pty version`

### DIFF
--- a/completions/pty.bash
+++ b/completions/pty.bash
@@ -7,12 +7,12 @@ _pty() {
   COMPREPLY=()
   cur="${COMP_WORDS[COMP_CWORD]}"
   prev="${COMP_WORDS[COMP_CWORD-1]}"
-  commands="run attach a exec peek send events list ls stats restart kill rm remove gc tag tag-multi emit rename up down test help"
+  commands="run attach a exec peek send events list ls stats restart kill rm remove gc tag tag-multi emit rename up down test version help"
 
   # Complete subcommand (first positional).
   if [[ ${COMP_CWORD} -eq 1 ]]; then
     if [[ "${cur}" == -* ]]; then
-      COMPREPLY=($(compgen -W "--root --preselect-new --filter-tag --help -h" -- "${cur}"))
+      COMPREPLY=($(compgen -W "--root --preselect-new --filter-tag --help -h --version -v" -- "${cur}"))
     else
       COMPREPLY=($(compgen -W "${commands}" -- "${cur}"))
     fi

--- a/completions/pty.zsh
+++ b/completions/pty.zsh
@@ -38,6 +38,7 @@ _pty() {
     'up:Start sessions from pty.toml'
     'down:Stop sessions from pty.toml'
     'test:Run the pty test suite (vitest)'
+    'version:Print the version'
     'help:Show usage'
   )
 

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -5,6 +5,7 @@ import * as readline from "node:readline/promises";
 import { spawnSync, execFileSync } from "node:child_process";
 import { randomBytes } from "node:crypto";
 import { attach, peek, send, queryStats, type StatsResult } from "./client.ts";
+import { printVersion } from "./version.ts";
 import { parseSeqValue } from "./keys.ts";
 import {
   listSessions,
@@ -162,6 +163,7 @@ Multi (pty.toml):
 Global:
   pty --root <path> <subcommand> [...]    Pin the state registry for this call (== PTY_ROOT env)
   pty help | pty --help | pty -h          Show this usage
+  pty version | pty --version | pty -v    Print the version (<semver>+<short-sha>)
   pty test [watch | -t "pattern"]         Run the pty test suite (vitest passthrough)
 
 Session references (<ref>): the on-disk id (validated: [A-Za-z0-9._-], ≤ 255 chars,
@@ -1025,6 +1027,14 @@ async function main(): Promise<void> {
 
     case "test": {
       await cmdTest(args.slice(1));
+      break;
+    }
+
+    case "version":
+    case "--version":
+    case "-v":
+    case "-V": {
+      printVersion();
       break;
     }
 

--- a/src/version.ts
+++ b/src/version.ts
@@ -1,0 +1,49 @@
+import * as fs from "node:fs";
+import * as path from "node:path";
+import { execFileSync } from "node:child_process";
+
+/** Directory of this module (dist/ when built, src/ when run from source).
+ *  package.json is one level up in both layouts. */
+function selfDir(): string {
+  return import.meta.dirname ?? path.dirname(new URL(import.meta.url).pathname);
+}
+
+/** Semver from the shipped package.json. Falls back to "0.0.0" if it can't be
+ *  read (should never happen — npm always ships package.json). */
+export function readPackageVersion(): string {
+  try {
+    const pkg = JSON.parse(fs.readFileSync(path.join(selfDir(), "..", "package.json"), "utf8"));
+    return typeof pkg.version === "string" ? pkg.version : "0.0.0";
+  } catch {
+    return "0.0.0";
+  }
+}
+
+/** Short git sha of THIS pty checkout, or null when unavailable. Gated on a
+ *  `.git` in pty's own package root so an npm-installed copy sitting inside an
+ *  unrelated parent repo never reports that repo's sha as pty's version. */
+export function readGitShortSha(): string | null {
+  const root = path.join(selfDir(), "..");
+  try {
+    if (!fs.existsSync(path.join(root, ".git"))) return null;
+    const sha = execFileSync("git", ["rev-parse", "--short", "HEAD"], {
+      cwd: root,
+      encoding: "utf8",
+      stdio: ["ignore", "pipe", "ignore"],
+    }).trim();
+    return /^[0-9a-f]{4,}$/.test(sha) ? sha : null;
+  } catch {
+    return null;
+  }
+}
+
+/** Format per house convention: `<semver>+<short-sha>`, or bare `<semver>` when
+ *  no git sha is available. Pure — exported for unit testing. */
+export function formatVersion(version: string, sha: string | null): string {
+  return sha ? `${version}+${sha}` : version;
+}
+
+/** Print the version as `<semver>+<short-sha>` (or bare `<semver>`). */
+export function printVersion(): void {
+  console.log(formatVersion(readPackageVersion(), readGitShortSha()));
+}

--- a/tests/version.test.ts
+++ b/tests/version.test.ts
@@ -1,0 +1,46 @@
+import { describe, it, expect } from "vitest";
+import * as fs from "node:fs";
+import * as path from "node:path";
+import { fileURLToPath } from "node:url";
+import { spawnSync } from "node:child_process";
+import { formatVersion } from "../src/version.ts";
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const nodeBin = process.execPath;
+const cliPath = path.join(__dirname, "..", "dist", "cli.js");
+const pkgVersion = JSON.parse(
+  fs.readFileSync(path.join(__dirname, "..", "package.json"), "utf8"),
+).version as string;
+
+describe("formatVersion", () => {
+  it("appends +<sha> when a sha is present", () => {
+    expect(formatVersion("0.11.0", "abcdef1")).toBe("0.11.0+abcdef1");
+  });
+
+  it("prints bare semver when there is no sha (e.g. npm install)", () => {
+    expect(formatVersion("0.11.0", null)).toBe("0.11.0");
+  });
+});
+
+describe("pty --version", () => {
+  // `<semver>` optionally followed by `+<short-sha>`. Tests run inside the git
+  // checkout, so the sha part is present here; the no-sha path is covered by
+  // the formatVersion unit test above.
+  const VERSION_RE = /^\d+\.\d+\.\d+(\+[0-9a-f]{4,})?$/;
+
+  for (const form of ["--version", "version", "-v", "-V"]) {
+    it(`\`pty ${form}\` prints the version and exits 0`, () => {
+      const r = spawnSync(nodeBin, [cliPath, form], { encoding: "utf8", timeout: 15000 });
+      expect(r.status).toBe(0);
+      const out = r.stdout.trim();
+      expect(out).toMatch(VERSION_RE);
+      // The semver part must match package.json.
+      expect(out.split("+")[0]).toBe(pkgVersion);
+    });
+  }
+
+  it("is not treated as an unknown command", () => {
+    const r = spawnSync(nodeBin, [cliPath, "--version"], { encoding: "utf8", timeout: 15000 });
+    expect(r.stderr).not.toContain("Unknown command");
+  });
+});


### PR DESCRIPTION
## Problem

Fresh-clone onboarding papercut: `pty --version` printed `Unknown command: --version`. A new user sanity-checking their install hits an error (st and convoy both print a version).

## Fix

Add a version command — `pty version`, `pty --version`, `pty -v`, `pty -V` — printing the version per house convention **`<semver>+<short-sha>`** (e.g. `0.11.0+c87a6c6`):
- **semver** from `package.json`
- **short sha** from git when this is a pty checkout; **gracefully omitted** otherwise, so an npm install prints bare `0.11.0`

### Correctness note
The sha lookup is gated on a `.git` existing in **pty's own package root** and runs `git rev-parse` with `cwd` set there — so an npm-installed copy sitting inside an *unrelated* parent git repo never reports that repo's sha as pty's version.

## Changes
- `src/version.ts` — new import-safe module (`readPackageVersion` / `readGitShortSha` / `formatVersion` / `printVersion`). Kept separate from `cli.ts` because `cli.ts` runs `main()` on import, so its exports aren't test-importable.
- `src/cli.ts` — version switch cases + a Global help line.
- `completions/pty.bash`, `completions/pty.zsh` — add `version` (+ `--version`/`-v`).
- `tests/version.test.ts` — unit tests for `formatVersion` (with/without sha, covering the npm-install bare-semver path) + integration tests that each form prints the version and exits 0.

## Verification
- All four forms print e.g. `0.11.0+c87a6c6`; `pty --help` shows the new line.
- `npm run typecheck` clean; version test 7/7; dispatch tests (nesting/exec) still green.
