### PR TITLE
fix(root): warn when PTY_ROOT masks a co-set PTY_SESSION_DIR

### DIFF
--- a/README.md
+++ b/README.md
@@ -168,6 +168,8 @@ Distinct roots share no sockets, no metadata, no events, no gc. A launchd cron (
 
 `PTY_SESSION_DIR` (the pre-Phase-2 name for the same env var) still works and emits a one-time deprecation notice. Set `PTY_ROOT_LEGACY_SILENT=1` to suppress the notice while migrating.
 
+**`PTY_ROOT` is the isolation mechanism — use it, not `PTY_SESSION_DIR`.** When both are set, `PTY_ROOT` (canonical) wins and the deprecated `PTY_SESSION_DIR` is ignored — with a one-time warning so the masking is visible. So a scratch/test harness running inside an environment that already exports `PTY_ROOT` (e.g. a supervised session tree) must set `PTY_ROOT` to isolate; setting only `PTY_SESSION_DIR` would be silently overridden by the ambient `PTY_ROOT` and its sessions would land in the ambient registry.
+
 ### Project Files
 
 A project can include a `pty.toml` to declare its sessions:

--- a/src/sessions.ts
+++ b/src/sessions.ts
@@ -12,6 +12,7 @@ import { appendEventSync } from "./events.ts";
 export const DEFAULT_SESSION_DIR = path.join(os.homedir(), ".local", "state", "pty");
 
 let hasWarnedLegacyRootEnv = false;
+let hasWarnedRootMasksLegacy = false;
 
 const DEAD_SESSION_TTL_MS = 24 * 60 * 60 * 1000; // 24 hours
 
@@ -70,8 +71,22 @@ export function validateDisplayName(name: string): void {
 
 export function getSessionDir(): string {
   const root = process.env.PTY_ROOT;
-  if (root && root.length > 0) return root;
   const legacy = process.env.PTY_SESSION_DIR;
+  if (root && root.length > 0) {
+    // PTY_ROOT (canonical) wins. If a caller ALSO set the deprecated
+    // PTY_SESSION_DIR — e.g. a test/scratch harness trying to isolate — it's
+    // silently masked, so their sessions land under PTY_ROOT instead of the dir
+    // they asked for. Warn once (unless silenced) so the masking is visible
+    // rather than an invisible leak into the wrong registry.
+    if (legacy && legacy.length > 0 && !hasWarnedRootMasksLegacy && !process.env.PTY_ROOT_LEGACY_SILENT) {
+      hasWarnedRootMasksLegacy = true;
+      process.stderr.write(
+        `pty: both PTY_ROOT and PTY_SESSION_DIR are set — using PTY_ROOT (${root}); ` +
+        `PTY_SESSION_DIR (${legacy}) is ignored (deprecated). For isolation, set PTY_ROOT.\n`
+      );
+    }
+    return root;
+  }
   if (legacy && legacy.length > 0) {
     if (!hasWarnedLegacyRootEnv && !process.env.PTY_ROOT_LEGACY_SILENT) {
       hasWarnedLegacyRootEnv = true;

--- a/tests/pty-root.test.ts
+++ b/tests/pty-root.test.ts
@@ -193,3 +193,66 @@ describe("pty gc --print-launchd-plist per-root Label + logPath", () => {
     expect(plist).toContain("<string>com.myobie.pty.gc.weird-name-with-spaces</string>");
   });
 });
+
+describe("run -d honors PTY_ROOT for isolation; PTY_SESSION_DIR masking is visible", () => {
+  // Regression for the scratch-session leak: a detached session must land in
+  // PTY_ROOT and NOT in a co-set (deprecated) PTY_SESSION_DIR or the default
+  // registry. PTY_ROOT is the isolation mechanism; PTY_SESSION_DIR is legacy.
+  it("a -d session lands ONLY under PTY_ROOT (not the co-set PTY_SESSION_DIR, not the default)", () => {
+    const root = makeRoot();
+    const scratch = makeRoot(); // legacy var that must be ignored
+    const name = `rd${Math.random().toString(36).slice(2, 7)}`;
+    // `cat` waits on stdin, so the session stays running while we inspect.
+    const res = runCli(["run", "-d", "--id", name, "--", "cat"], {
+      PATH: process.env.PATH,
+      HOME: process.env.HOME,
+      PTY_ROOT: root,
+      PTY_SESSION_DIR: scratch,
+      PTY_ROOT_LEGACY_SILENT: "1",
+    });
+    try {
+      expect(res.status).toBe(0);
+      // Landed under PTY_ROOT.
+      expect(fs.existsSync(path.join(root, `${name}.json`))).toBe(true);
+      expect(fs.existsSync(path.join(root, `${name}.sock`))).toBe(true);
+      // NOT under the deprecated PTY_SESSION_DIR.
+      expect(fs.existsSync(path.join(scratch, `${name}.json`))).toBe(false);
+      // NOT in the real default registry.
+      const def = path.join(os.homedir(), ".local", "state", "pty", `${name}.json`);
+      expect(fs.existsSync(def)).toBe(false);
+    } finally {
+      runCli(["kill", name], {
+        PATH: process.env.PATH,
+        HOME: process.env.HOME,
+        PTY_ROOT: root,
+        PTY_ROOT_LEGACY_SILENT: "1",
+      });
+    }
+  });
+
+  it("warns (once) that PTY_ROOT wins when PTY_SESSION_DIR is also set", () => {
+    const res = runCli(["list", "--json"], {
+      PATH: process.env.PATH,
+      HOME: process.env.HOME,
+      PTY_ROOT: makeRoot(),
+      PTY_SESSION_DIR: makeRoot(),
+      // no PTY_ROOT_LEGACY_SILENT → the masking warning should surface
+    });
+    expect(res.status).toBe(0);
+    expect(res.stderr).toMatch(/both PTY_ROOT and PTY_SESSION_DIR are set/);
+    // Exactly once per invocation.
+    expect(res.stderr.match(/both PTY_ROOT and PTY_SESSION_DIR are set/g)?.length).toBe(1);
+  });
+
+  it("PTY_ROOT_LEGACY_SILENT suppresses the masking warning", () => {
+    const res = runCli(["list", "--json"], {
+      PATH: process.env.PATH,
+      HOME: process.env.HOME,
+      PTY_ROOT: makeRoot(),
+      PTY_SESSION_DIR: makeRoot(),
+      PTY_ROOT_LEGACY_SILENT: "1",
+    });
+    expect(res.status).toBe(0);
+    expect(res.stderr).not.toMatch(/both PTY_ROOT and PTY_SESSION_DIR/);
+  });
+});


### PR DESCRIPTION
## Context

Follow-up to the scratch-session leak: a harness that set the deprecated `PTY_SESSION_DIR` to isolate, while running in an env that already exports `PTY_ROOT` (a supervised session tree like convoy), had its `PTY_SESSION_DIR` **silently masked** — `getSessionDir()` prefers the canonical `PTY_ROOT` — so its scratch sessions landed in the ambient (production) registry.

Per the decision: **precedence stays as-is** (canonical `PTY_ROOT` wins over the deprecated legacy var — reversing that would make a deprecated var beat the canonical one and change every command). The fix is **visibility**, not behavior.

## Fix

- **`src/sessions.ts`** — `getSessionDir()` now emits a one-time warning (unless `PTY_ROOT_LEGACY_SILENT`) when **both** `PTY_ROOT` and `PTY_SESSION_DIR` are set, naming both dirs and pointing at `PTY_ROOT` as the isolation mechanism. The masking becomes obvious instead of an invisible leak. The returned dir is unchanged.
- **`tests/pty-root.test.ts`** — the regression cos asked for: a `pty run -d` session with `PTY_ROOT` set lands **ONLY** under it (not the co-set `PTY_SESSION_DIR`, not the default registry). Plus: the warning surfaces when both are set, and `PTY_ROOT_LEGACY_SILENT` suppresses it.
- **`README`** — documents that `PTY_ROOT` is the isolation mechanism and explains the masking + warning.

## Verification

- `pty-root` suite: 16/16 (3 new).
- `npm run typecheck` clean; manual: `PTY_ROOT=A PTY_SESSION_DIR=B pty list` prints the masking warning to stderr and uses A.

## Note (unrelated, flagged)

The full suite had one **flaky** failure in `demos/agent-teams/agents-integration.test.ts` (a TUI render assertion — "Activity") that **passes standalone (11/11, twice)** and doesn't touch any session-dir logic. It's a pre-existing render-timing flake under parallel load, not from this change — flagging for a separate look.
