### PR TITLE
feat(cli): per-subcommand --help, thin SKILL.md, 0.3s default --seq delay

### DIFF
--- a/docs/SKILL.md
+++ b/docs/SKILL.md
@@ -1,153 +1,75 @@
-# PTY — Run and manage background processes
+---
+name: pty
+description: >-
+  Run and manage long-lived or background processes — dev servers, test suites,
+  builds, interactive CLIs, agents — in persistent, detachable terminal
+  sessions. Reach for pty INSTEAD of `&` / nohup / raw background shell whenever
+  you need to start work, go do something else, then come back to read its
+  output, send it input, or restart it; and for any interactive tool that needs
+  a real TTY (auth/keychain prompts, TUIs, REPLs).
+when_to_use: >-
+  An agent needs to start a process and check on it later; run a dev server /
+  test suite / build and wait for a readiness or result line; drive an
+  interactive CLI that needs a real terminal; or keep a process alive across
+  disconnects. NOT for one-shot commands whose output you read immediately —
+  run those directly.
+---
 
-Run `pty --help` to see the full command reference.
+# pty — persistent terminal sessions
 
-Use `pty` to run processes in managed terminal sessions. Prefer pty over raw
-background commands (`&`, `nohup`, piping) for better lifecycle control,
-readable output, and the ability to wait for results.
+## What it is
+`pty` runs a command in a managed terminal session you can detach from and
+reconnect to later, from anywhere (including over SSH). It's the terminal /
+session layer: `run`, `list`, `peek`, `send`, `restart`, `kill`, `up`.
 
-## When to use
+## When to reach for it
+- A long-lived / background process: dev server, test suite, build, watcher, an agent.
+- An interactive CLI that needs a real TTY: keychain/auth prompts, a TUI, a REPL.
+- Any "start it, go do something else, come back to read / send / restart" task.
 
-- Running any long-lived or background process (dev servers, test suites, builds)
-- Interactive CLI tools that need a real terminal (auth via keychain, TUI, REPL)
-- Any task where you want to start work, do something else, then check results
-- Processes you may need to re-read output from later
+Prefer `pty` over `&` / `nohup` / pipes for these — you get lifecycle control,
+readable replayed output, and the ability to wait for specific text. For a
+one-shot command whose output you read right now, just run it directly.
 
-## Session lifecycle
-
-`strategy=permanent` sessions are restarted by `pty gc` (typically a launchd `StartInterval=30` task — `pty gc --print-launchd-plist > ~/Library/LaunchAgents/com.myobie.pty.gc.plist`). Restarts are stateless — no backoff tracking, no retry budget. Expect up to one interval of latency before a session comes back.
-
-### 1. Create a detached session
-
-```bash
-pty run -d --name <descriptive-name> --tag owner=<agent> -- <command> [args...]
+## The idiom (happy path)
+```sh
+pty run -d --name <name> --tag owner=<you> -- <command>   # start detached, tagged
+pty peek --wait "<ready text>" --plain <name> -t 30       # block until ready
+pty peek --full --plain <name>                            # read full output
+pty send <name> --seq "<text>" --seq key:return           # send input + Enter
+pty kill <name>                                           # clean up when done
 ```
+Tag the sessions you create; only touch sessions you created.
 
-Use `--cwd` to run in a specific directory:
+## Footguns (the ones that actually bite)
+- **A broken global `pty` on `$PATH` silently breaks the whole message bus.**
+  `st` / smalltalk delivery shells out to `pty send` found on `$PATH`. If a
+  global-install symlink points at a stale or broken `pty`, *every* agent's
+  message delivery fails network-wide — silently. Run `pty` from the intended
+  install; if you do global-install, confirm `pty --version` works before
+  trusting delivery.
+- **Isolation is `PTY_ROOT`, not `PTY_SESSION_DIR`.** To keep scratch/test
+  sessions out of the production registry, set `PTY_ROOT=<dir>`.
+  `PTY_SESSION_DIR` is a deprecated alias and is *ignored* when `PTY_ROOT` is
+  already set (as it is inside a supervised session tree) — so setting only
+  `PTY_SESSION_DIR` there leaks your sessions into the ambient registry. pty
+  now warns when both are set.
+- **Sending text + Enter: mind the timing (top cause of "I sent it but nothing
+  happened").** `pty send <ref> "text"` sends NO newline — to submit, use
+  `pty send <ref> --seq "text" --seq key:return`. The *why* it can silently fail:
+  a terminal program processes a burst of bytes differently from spaced-out
+  input. With zero spacing, the trailing `key:return` routinely arrives before
+  the program's readline / PTY event loop has parsed and rendered the typed
+  text (and before bracketed-paste framing closes), so the Enter submits an
+  empty or partial line. `pty send` now inserts a **0.3s gap between `--seq`
+  items by default** so each chunk is consumed before the next — you usually
+  don't need to think about it. Overrides: `--with-delay <sec>` to tune (some
+  slow TUIs want 0.5s+), and **`--with-delay 0` for a raw back-to-back stream**
+  (fast/bulk sends where you know the receiver can take it).
+- **Don't nest.** Inside a session, a bare `pty run` runs the command directly
+  (nesting guard); use `pty run -d` to explicitly background a new session from
+  inside one.
 
-```bash
-pty run -d --name <name> --cwd /path/to/project --tag owner=<agent> -- <command>
-```
-
-Tag sessions so they are identifiable. Never touch sessions you did not create.
-
-### 2. Wait for the process to be ready
-
-```bash
-pty peek --wait "expected text" --plain <name> -t 10
-```
-
-Check the output to confirm the process has started (e.g. "Authenticated",
-"Listening", a prompt character).
-
-### 3. Send input (if interactive)
-
-```bash
-pty send <name> "your message here"
-pty send <name> --seq key:return
-```
-
-For multi-step input use `--seq` chains:
-
-```bash
-pty send <name> --seq "first line" --seq key:return
-```
-
-Use `--with-delay` if the tool needs time between inputs:
-
-```bash
-pty send <name> --with-delay 0.5 --seq "text" --seq key:return
-```
-
-### 4. Wait for output and read results
-
-Wait for specific text to appear:
-
-```bash
-pty peek --wait "expected output" --plain <name> -t 120
-```
-
-Read the full scrollback (not just the visible screen):
-
-```bash
-pty peek --full --plain <name>
-```
-
-Read just the current visible screen:
-
-```bash
-pty peek --plain <name>
-```
-
-Check recent events without following:
-
-```bash
-pty events --recent <name>
-```
-
-### 5. Clean up
-
-Always kill sessions you created when done:
-
-```bash
-pty kill <name>
-```
-
-## Rules
-
-- **Always use `--plain` with peek** so output is readable (no ANSI escapes)
-- **Always use `-t` (timeout)** on `--wait` so you don't block forever
-- **Always tag sessions** so they are identifiable and attributable
-- **Always clean up** — kill sessions when you are done
-- **Never touch sessions you did not create** — check `pty list --tags` if unsure
-- **Use `--full` when output may exceed the screen** — peek without it only
-  shows the visible terminal buffer
-
-## Naming conventions
-
-Name sessions by purpose: `gemini-review`, `test-runner`, `dev-server`, etc.
-Keep names lowercase with hyphens.
-
-## Quick reference
-
-| Action | Command |
-|---|---|
-| Create detached | `pty run -d --name <n> --tag owner=<a> -- <cmd>` |
-| Peek (plain) | `pty peek --plain <n>` |
-| Peek (full scrollback) | `pty peek --full --plain <n>` |
-| Wait for text | `pty peek --wait "text" --plain <n> -t 30` |
-| Send text | `pty send <n> "text"` |
-| Send enter | `pty send <n> --seq key:return` |
-| Recent events | `pty events --recent <n>` |
-| Follow events | `pty events <n>` |
-| List sessions | `pty list --tags` |
-| Kill session | `pty kill <n>` |
-
-## Common patterns
-
-### Run a dev server and wait for it
-
-```bash
-pty run -d --name dev-server --tag owner=agent -- npm run dev
-pty peek --wait "Listening" --plain dev-server -t 30
-# Server is ready — do your work
-pty kill dev-server
-```
-
-### Run tests and read results
-
-```bash
-pty run -d --name tests --tag owner=agent -- npm test
-pty peek --wait "passed" --wait "failed" --plain tests -t 120
-pty peek --full --plain tests
-pty kill tests
-```
-
-### Run a build and check for errors
-
-```bash
-pty run -d --name build --tag owner=agent -- npm run build
-pty peek --wait "error" --wait "successfully" --plain build -t 60
-pty peek --full --plain build
-pty kill build
-```
+## The exact surface
+Run `pty --help` for the full subcommand list, and `pty <subcommand> --help` for
+that command's flags and examples. `pty --version` prints `<semver>+<short-sha>`.

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -4,7 +4,7 @@ import * as path from "node:path";
 import * as readline from "node:readline/promises";
 import { spawnSync, execFileSync } from "node:child_process";
 import { randomBytes } from "node:crypto";
-import { attach, peek, send, queryStats, type StatsResult } from "./client.ts";
+import { attach, peek, send, queryStats, resolveSeqDelayMs, type StatsResult } from "./client.ts";
 import { printVersion } from "./version.ts";
 import { parseSeqValue } from "./keys.ts";
 import {
@@ -71,6 +71,271 @@ function extractFilterTags(args: string[]): Record<string, string> {
   }
 }
 
+// Per-subcommand help. `pty <cmd> --help` (or `-h`) prints the matching entry:
+// usage synopsis, every flag, and at least one concrete example. Kept here as
+// the single source so the deprecation/error paths and --help never drift.
+// A test (tests/help.test.ts) asserts every subcommand has an entry.
+const COMMAND_HELP: Record<string, string> = {
+  run: `Usage: pty run [flags] -- <command> [args...]
+
+Create a session and attach to it (use -d to leave it running in the background).
+
+Flags:
+  --id <id>            Pin the on-disk id (sock/json filename; charset-validated, ≤ 104-byte sock path)
+  --name <label>       Explicit display label (any printable text, ≤ 500 chars)
+  --no-display-name    Skip the auto cwd+command label — just the id
+  -d, --detach         Create in the background; don't attach
+  -a, --attach         Create, OR attach if a session with the same id already exists
+  -e, --ephemeral      Auto-remove metadata on clean exit
+  --tag key=value      Tag the session (repeatable)
+  --cwd <path>         Working directory for the command
+  --isolate-env        Scrub the child env to a safe allow-list (for remote-reachable sessions)
+  --force              Create even from inside another pty session (bypass the nesting guard)
+
+Examples:
+  pty run -- node server.js
+  pty run -d --name "API" --tag role=web -- node server.js`,
+
+  attach: `Usage: pty attach [-r] [--force] <ref>
+
+Reconnect to a session (alias: pty a). Detach again with Ctrl+\\.
+
+Flags:
+  -r, --auto-restart   Auto-restart the session if it has exited
+  --force              Attach even from inside another pty session (nested)
+
+Examples:
+  pty attach myserver
+  pty attach -r myserver`,
+
+  exec: `Usage: pty exec -- <command> [args...]
+
+Replace the current session's leaf process with a new command. Run INSIDE a
+session (uses $PTY_SESSION); the session keeps its id and metadata.
+
+Examples:
+  pty exec -- codex
+  pty exec -- bash -l`,
+
+  peek: `Usage: pty peek [-f] [--plain] [--full] [--wait <text> [-t <sec>]] <ref>
+
+Print a session's screen (or follow it, or wait for text) without attaching.
+
+Flags:
+  --plain              Plain text, no ANSI escapes (best for scripts / agents)
+  --full               Full scrollback, not just the visible viewport
+  -f, --follow         Follow output read-only (Ctrl+\\ to stop)
+  --wait <text>        Block until <text> appears on screen
+  -t, --timeout <sec>  Timeout (seconds) for --wait
+
+Examples:
+  pty peek --plain myserver
+  pty peek --wait "Listening" -t 10 --plain myserver`,
+
+  send: `Usage: pty send <ref> "text"
+       pty send <ref> --seq <chunk> [--seq key:<name>] ...
+
+Send text or key events to a session. Raw text is sent with NO implicit newline —
+to send text followed by Enter, use --seq (see the second example).
+
+Flags:
+  --seq <value>        Ordered chunk or key event (repeatable). key:<name> sends a
+                       key, e.g. key:return, key:ctrl+c, key:tab
+  --with-delay <sec>   Delay (seconds) between --seq items. DEFAULT 0.3s so a
+                       trailing key:return doesn't race ahead of the program
+                       parsing the text. --with-delay 0 = straight stream (no gap).
+  --paste "<text>"     Wrap the payload in bracketed-paste markers
+
+Examples:
+  pty send myserver "hello"
+  pty send myserver --seq "git status" --seq key:return        # 0.3s gap by default
+  pty send myserver --with-delay 0 --seq a --seq b --seq c     # back-to-back, no gap`,
+
+  events: `Usage: pty events [--all | <ref>] [--recent] [--json] [--wait <type> [-t <sec>]]
+
+Follow a session's event log (bell, title, notifications, tag/rename changes, user.* events).
+
+Flags:
+  --all                Follow every session, interleaved (omit <ref>)
+  --recent             Print recent events and exit (don't follow)
+  --json               Emit raw JSONL
+  --wait <type>        Block until an event of <type> appears
+  -t, --timeout <sec>  Timeout (seconds) for --wait
+
+Examples:
+  pty events myserver
+  pty events --recent --json myserver`,
+
+  list: `Usage: pty list [--json] [--tags] [--filter-tag k=v] [--remote] [--status <s>] [--summary]
+
+List sessions (alias: pty ls). User tags show by default.
+
+Flags:
+  --json               Emit JSON
+  --tags               Include internal bookkeeping tags (ptyfile*, strategy.*)
+  --filter-tag k=v     Only sessions with the tag (repeatable, ALL must match)
+  --remote             Include remote sessions via pty-relay (when installed)
+  --status <state>     Filter by status: running | exited | vanished
+  --older-than <dur>   Only sessions older than a duration (e.g. 30m, 2h, 3d)
+  --newer-than <dur>   Only sessions newer than a duration
+  --summary            Print a one-line count summary instead of the list
+
+Examples:
+  pty list
+  pty list --filter-tag role=web --json`,
+
+  stats: `Usage: pty stats [--json] [--all] [<ref>]
+
+Live CPU / memory / PIDs. Omit <ref> for every session.
+
+Flags:
+  --json               Emit stats as JSON (one snapshot)
+  --all                Include every session (with an explicit <ref> given)
+
+Examples:
+  pty stats
+  pty stats --json myserver`,
+
+  restart: `Usage: pty restart [-y] [--force] <ref>
+
+SIGTERM the session's daemon and respawn it from stored metadata (command, cwd,
+tags, displayName). Prompts first if it's still running.
+
+Flags:
+  -y, --yes            Skip the "kill and restart?" prompt
+  --force              Attach after restart even from inside another pty session
+
+Examples:
+  pty restart myserver
+  pty restart -y myserver`,
+
+  kill: `Usage: pty kill <ref>
+
+SIGTERM a running session's daemon. Metadata is kept — restart or \`pty rm\` it later.
+
+Examples:
+  pty kill myserver`,
+
+  rm: `Usage: pty rm <ref>
+
+Remove an exited session's files (socket/pid/json/events) (alias: pty remove).
+Won't remove a running session — kill it first.
+
+Examples:
+  pty rm myserver`,
+
+  gc: `Usage: pty gc [-n] [--idle-days N] [--fast-fail-window=N] [--fast-fail-limit=N]
+       pty gc --print-launchd-plist [--interval=N]
+
+One reconciliation pass: sweep exited/vanished, orphan-kill \`parent=<name>\` children,
+reap abandoned permanents, respawn \`strategy=permanent\` sessions.
+
+Flags:
+  -n, --dry-run           Preview without changing anything
+  --idle-days N           Also reap permanents with no attach in N days
+  --fast-fail-window=N    Fast-fail window seconds (default 60; per-session tag wins)
+  --fast-fail-limit=N     Consecutive fast fails before flapping (default 3; per-session tag wins)
+  --print-launchd-plist   Print a macOS launchd plist that runs 'pty gc' on an interval
+  --interval=N            Plist StartInterval seconds (default 30)
+
+Examples:
+  pty gc --dry-run
+  pty gc --print-launchd-plist > ~/Library/LaunchAgents/com.myobie.pty.gc.plist`,
+
+  tag: `Usage: pty tag <ref>                           Show tags
+       pty tag <ref> key=value [key=value...]   Set tags
+       pty tag <ref> --rm key [--rm key...]     Remove tags
+
+Read or write tags on one session. Updates apply before removals.
+
+Flags:
+  --rm <key>           Remove a tag key (repeatable)
+
+Examples:
+  pty tag myserver role=web env=prod
+  pty tag myserver --rm env`,
+
+  "tag-multi": `Usage: pty tag-multi <selector> [ops...]
+
+Bulk read / write tags across many sessions.
+  Selector (one of): --all | --filter-tag k=v (repeatable) | <ref>...
+  Ops (any of):      key=value | --rm key
+
+Flags:
+  --all                Select every session
+  --filter-tag k=v     Select sessions with the tag (repeatable)
+  --rm <key>           Remove a tag key (repeatable)
+  --json               Read mode: emit tags as JSON
+  -y, --yes            Required to write when the selector is --all
+
+Examples:
+  pty tag-multi --filter-tag role=web env=prod
+  pty tag-multi --all --json`,
+
+  emit: `Usage: pty emit <type> [--json <payload>] [--text <string>]
+       pty emit <ref> <type> [--json <payload>] [--text <string>]
+
+Publish a user.* event to a session's event log. Inside a session the ref
+defaults to $PTY_SESSION. Types must start with "user." — "session_*", "state.*",
+"bell", etc. are reserved.
+
+Flags:
+  --json <payload>     Attach a JSON payload
+  --text <string>     Attach a text payload
+
+Examples:
+  pty emit user.build-done
+  pty emit user.progress --json '{"pct": 40}'
+  pty emit myserver user.tests-passed --json '{"n": 42}'`,
+
+  rename: `Usage: pty rename <new-display-name>          Inside a session: set displayName
+       pty rename <ref> <new-display-name>    Outside: set displayName on <ref>
+       pty rename --show <ref>                Show the current displayName
+       pty rename --clear [ref]               Clear the displayName
+
+displayName is a mutable alias; the session's stable id (name) never changes.
+
+Examples:
+  pty rename my-friendly-name
+  pty rename webapp "Web Frontend"
+  pty rename --show webapp`,
+
+  up: `Usage: pty up [<dir>] [<name>...]
+
+Start sessions declared in a pty.toml. With no args, reads ./pty.toml and starts all.
+
+Examples:
+  pty up
+  pty up ./backend
+  pty up web worker`,
+
+  down: `Usage: pty down [<dir>] [<name>...]
+
+Stop sessions declared in a pty.toml.
+
+Examples:
+  pty down
+  pty down web`,
+
+  test: `Usage: pty test [watch | -t "<pattern>"]
+
+Run the pty test suite (a thin vitest passthrough).
+
+Examples:
+  pty test
+  pty test -t "peek"`,
+};
+
+/** Print a subcommand's focused help. Resolves aliases; returns false for an
+ *  unknown command so the caller can fall through. */
+function printCommandHelp(cmd: string): boolean {
+  const canonical = ({ a: "attach", ls: "list", remove: "rm" } as Record<string, string>)[cmd] ?? cmd;
+  const help = COMMAND_HELP[canonical];
+  if (!help) return false;
+  console.log(help);
+  return true;
+}
+
 function usage(): void {
   console.log(`Usage:
   pty                                     Interactive session manager (fullscreen TUI)
@@ -90,6 +355,7 @@ Create sessions:
   pty run --cwd /path -- <command>        Run in a specific directory
   pty run --isolate-env -- <command>      Scrub the child env to a safe allow-list
                                           (intended for remote-reachable sessions)
+  pty run --force -- <command>            Create even from inside another pty session (nested)
 
 Attach & interact:
   pty attach <ref>                        Attach to an existing session (alias: pty a)
@@ -98,7 +364,8 @@ Attach & interact:
   pty exec -- <command> [args...]         Replace the current session's process (inside a session)
   pty send <ref> "text"                   Send raw text (no implicit newline)
   pty send <ref> --seq "text" --seq key:return   Send an ordered sequence of chunks / key events
-  pty send <ref> --with-delay 0.5 --seq ...      Insert a delay (seconds) between --seq items
+                                          (0.3s gap between items by default)
+  pty send <ref> --with-delay <sec> --seq ...    Override the gap; --with-delay 0 = straight stream
   pty send <ref> --paste "<big text>"     Wrap the payload in bracketed-paste markers
 
 Observe:
@@ -325,6 +592,14 @@ async function main(): Promise<void> {
   }
 
   const command = dispatchArgs[0];
+
+  // A subcommand's own `--help` / `-h` (in the first position after the command)
+  // prints that command's focused help and exits 0. `--root <path>` is already
+  // spliced out of `args` above, so `args[1]` is the token after the subcommand.
+  // First-position only, so `pty send <ref> --help` still sends "--help" as text.
+  if ((args[1] === "-h" || args[1] === "--help") && printCommandHelp(command)) {
+    return;
+  }
 
   switch (command) {
     case "interactive":
@@ -683,7 +958,9 @@ async function main(): Promise<void> {
       send({
         name: resolvedSendName,
         data,
-        delayMs: delaySecs != null ? delaySecs * 1000 : undefined,
+        // Default to a 0.3s inter-item gap so a trailing key:return doesn't race
+        // ahead of the program parsing the typed text. `--with-delay 0` opts out.
+        delayMs: resolveSeqDelayMs(delaySecs),
         ...(paste ? { paste: true } : {}),
       });
       break;
@@ -964,11 +1241,7 @@ async function main(): Promise<void> {
     }
 
     case "up": {
-      if (args[1] === "-h" || args[1] === "--help") {
-        console.log("Usage: pty up [dir] [name...]\n\nStart sessions defined in pty.toml.");
-        break;
-      }
-      // pty up [dir] [name...]
+      // pty up [dir] [name...]  (--help handled by the central interceptor)
       const upArgs = args.slice(1);
       let dir: string | undefined;
       const names: string[] = [];
@@ -987,11 +1260,7 @@ async function main(): Promise<void> {
     }
 
     case "down": {
-      if (args[1] === "-h" || args[1] === "--help") {
-        console.log("Usage: pty down [dir] [name...]\n\nStop sessions defined in pty.toml.");
-        break;
-      }
-      // pty down [dir] [name...]
+      // pty down [dir] [name...]  (--help handled by the central interceptor)
       const downArgs = args.slice(1);
       let dir: string | undefined;
       const names: string[] = [];
@@ -1831,16 +2100,9 @@ async function cmdKill(name: string): Promise<void> {
 }
 
 function renameUsage(): void {
-  console.error(
-    "Usage:\n" +
-    "  pty rename <new-display-name>         Inside a session: set displayName on the current session\n" +
-    "  pty rename <ref> <new-display-name>   Outside: set displayName on <ref>\n" +
-    "  pty rename --show <ref>               Show the current displayName for <ref>\n" +
-    "  pty rename --clear                    Inside a session: clear displayName\n" +
-    "  pty rename --clear <ref>              Outside: clear displayName on <ref>\n" +
-    "\n" +
-    "displayName is a mutable alias. The session's stable id (name) never changes."
-  );
+  // Single source of truth: the same text `pty rename --help` prints, to stderr
+  // for the error paths.
+  console.error(COMMAND_HELP.rename);
 }
 
 async function cmdRename(rawArgs: string[]): Promise<void> {
@@ -2455,19 +2717,8 @@ async function cmdEmit(argv: string[]): Promise<void> {
 }
 
 function printEmitHelp(): void {
-  console.log(`Usage:
-  pty emit <type> [--json <payload>] [--text <string>]
-  pty emit <session-ref> <type> [--json <payload>] [--text <string>]
-
-Publishes a user.* event to a session's events log. Inside a pty
-session, the ref defaults to $PTY_SESSION. Event types must start
-with "user." — "session_*", "state.*", "bell", etc. are reserved.
-
-Examples:
-  pty emit user.build-done
-  pty emit user.progress --json '{"pct": 40}'
-  pty emit user.note --text "starting deploy"
-  pty emit myserver user.tests-passed --json '{"n": 42}'`);
+  // Single source of truth: same text as `pty emit --help`.
+  console.log(COMMAND_HELP.emit);
 }
 
 // (state / wrap / unwrap removed in the lean-core pass — smalltalk's

--- a/src/client.ts
+++ b/src/client.ts
@@ -171,6 +171,22 @@ export interface SendOptions {
   paste?: boolean;
 }
 
+/** Default spacing (ms) the `pty send` CLI inserts between `--seq` items when
+ *  the caller doesn't pass `--with-delay`. A burst of bytes and spaced-out
+ *  input are processed differently by terminal programs — a trailing `key:return`
+ *  fired with zero delay routinely lands before the program has parsed/rendered
+ *  the typed text, submitting an empty or partial line. 0.3s lets each chunk be
+ *  consumed. See docs/SKILL.md. This default lives in the CLI layer only; the
+ *  library `send()` still treats `delayMs` literally (undefined/0 = no spacing). */
+export const DEFAULT_SEQ_DELAY_MS = 300;
+
+/** Resolve the `pty send` inter-item delay in ms from the `--with-delay <sec>`
+ *  argument: absent → the 0.3s default; an explicit value (including 0, the
+ *  straight-stream escape hatch) → that value. Pure; exported for testing. */
+export function resolveSeqDelayMs(withDelaySecs: number | undefined): number {
+  return withDelaySecs != null ? Math.round(withDelaySecs * 1000) : DEFAULT_SEQ_DELAY_MS;
+}
+
 /** Send data to a session without attaching. Silent on success. */
 export function send(options: SendOptions): void {
   const socketPath = getSocketPath(options.name);

--- a/tests/help.test.ts
+++ b/tests/help.test.ts
@@ -1,0 +1,73 @@
+import { describe, it, expect } from "vitest";
+import * as fs from "node:fs";
+import * as path from "node:path";
+import { fileURLToPath } from "node:url";
+import { spawnSync } from "node:child_process";
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const nodeBin = process.execPath;
+const cliPath = path.join(__dirname, "..", "dist", "cli.js");
+const cliSource = fs.readFileSync(path.join(__dirname, "..", "src", "cli.ts"), "utf8");
+
+// Canonical subcommands that must each ship focused `--help`.
+const COMMANDS = [
+  "run", "attach", "exec", "peek", "send", "events", "list", "stats",
+  "restart", "kill", "rm", "gc", "tag", "tag-multi", "emit", "rename",
+  "up", "down", "test",
+];
+// Aliases that must resolve to the same help.
+const ALIASES = ["a", "ls", "remove"];
+// Dispatch `case` labels that are NOT per-subcommand commands (no focused help
+// expected): the interactive TUI, and the global help/version verbs+flags.
+const NON_COMMAND_CASES = new Set([
+  "interactive", "i", "help", "--help", "-h", "version", "--version", "-v", "-V",
+]);
+
+function help(cmd: string) {
+  return spawnSync(nodeBin, [cliPath, cmd, "--help"], {
+    encoding: "utf8",
+    timeout: 15000,
+    env: { ...process.env, PTY_ROOT_LEGACY_SILENT: "1" },
+  });
+}
+
+describe("pty --help — per-subcommand help", () => {
+  for (const cmd of [...COMMANDS, ...ALIASES]) {
+    it(`\`pty ${cmd} --help\` prints usage + an example and exits 0`, () => {
+      const r = help(cmd);
+      expect(r.status).toBe(0);
+      // Usage synopsis.
+      expect(r.stdout).toMatch(/^Usage: pty /);
+      // At least one concrete example (an `Examples:` header or a `  pty …` line
+      // beyond the synopsis).
+      const exampleLines = r.stdout.split("\n").filter((l) => /^ {2}pty /.test(l));
+      expect(exampleLines.length).toBeGreaterThan(0);
+      // Help must not have executed the command (no session-list / JSON output).
+      expect(r.stdout).not.toMatch(/^\[/);
+    });
+  }
+});
+
+describe("pty --help — no drift", () => {
+  it("every dispatch `case` is either a documented command or a known non-command", () => {
+    // Extract every `case "X":` label from the dispatcher.
+    const cases = [...cliSource.matchAll(/case\s+"([^"]+)":/g)].map((m) => m[1]);
+    const documented = new Set([...COMMANDS, ...ALIASES]);
+    const uncovered = cases.filter((c) => !documented.has(c) && !NON_COMMAND_CASES.has(c));
+    // A new subcommand added without focused help (or without being listed as a
+    // non-command) will show up here — add it to COMMAND_HELP + this test.
+    expect(uncovered).toEqual([]);
+  });
+
+  it("top-level `pty --help` lists every subcommand", () => {
+    const r = spawnSync(nodeBin, [cliPath, "--help"], {
+      encoding: "utf8",
+      timeout: 15000,
+      env: { ...process.env, PTY_ROOT_LEGACY_SILENT: "1" },
+    });
+    expect(r.status).toBe(0);
+    for (const cmd of COMMANDS) {
+      expect(r.stdout).toContain(`pty ${cmd} `);
+    }
+  });
+});

--- a/tests/seq-delay.test.ts
+++ b/tests/seq-delay.test.ts
@@ -1,0 +1,105 @@
+import { describe, it, expect, afterAll } from "vitest";
+import * as fs from "node:fs";
+import * as os from "node:os";
+import * as path from "node:path";
+import { fileURLToPath } from "node:url";
+import { spawn, spawnSync } from "node:child_process";
+import { resolveSeqDelayMs, DEFAULT_SEQ_DELAY_MS } from "../src/client.ts";
+
+// (a) default (no --with-delay) inserts 0.3s between --seq items;
+// (b) --with-delay 0 = straight stream, NO spacing (the escape hatch);
+// (c) --with-delay N = N.
+
+describe("resolveSeqDelayMs — the `pty send --seq` delay decision", () => {
+  it("(a) defaults to 0.3s when --with-delay is absent", () => {
+    expect(DEFAULT_SEQ_DELAY_MS).toBe(300);
+    expect(resolveSeqDelayMs(undefined)).toBe(300);
+  });
+
+  it("(b) --with-delay 0 resolves to 0 (straight stream, no spacing)", () => {
+    expect(resolveSeqDelayMs(0)).toBe(0);
+  });
+
+  it("(c) --with-delay N resolves to N * 1000 ms", () => {
+    expect(resolveSeqDelayMs(0.1)).toBe(100);
+    expect(resolveSeqDelayMs(0.5)).toBe(500);
+    expect(resolveSeqDelayMs(2)).toBe(2000);
+  });
+});
+
+// End-to-end: prove the resolved delay is actually applied by `pty send`.
+// Timing is compared as a DELTA against the straight-stream baseline so node
+// startup cancels out and the assertions stay robust.
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const nodeBin = process.execPath;
+const cliPath = path.join(__dirname, "..", "dist", "cli.js");
+const serverModule = path.join(__dirname, "..", "dist", "server.js");
+const testRoot = fs.mkdtempSync(path.join(os.tmpdir(), "pty-seq-"));
+const bgPids: number[] = [];
+afterAll(() => {
+  for (const pid of bgPids) { try { process.kill(pid, "SIGTERM"); } catch {} }
+  fs.rmSync(testRoot, { recursive: true, force: true, maxRetries: 3, retryDelay: 100 });
+});
+
+async function startDaemon(dir: string, name: string): Promise<void> {
+  const config = JSON.stringify({
+    name, command: "cat", args: [], displayCommand: "cat",
+    cwd: os.tmpdir(), rows: 24, cols: 80,
+  });
+  const child = spawn(nodeBin, [serverModule], {
+    detached: true, stdio: ["ignore", "ignore", "ignore"],
+    env: { ...process.env, PTY_SERVER_CONFIG: config, PTY_SESSION_DIR: dir },
+  });
+  child.unref();
+  if (child.pid) bgPids.push(child.pid);
+  const sock = path.join(dir, `${name}.sock`);
+  const start = Date.now();
+  while (Date.now() - start < 5000) {
+    try { fs.statSync(sock); return; } catch {}
+    await new Promise((r) => setTimeout(r, 50));
+  }
+  throw new Error(`daemon "${name}" never started`);
+}
+
+/** Wall-clock ms of one `pty send` invocation. */
+function timeSend(dir: string, args: string[]): number {
+  const start = Date.now();
+  spawnSync(nodeBin, [cliPath, "send", ...args], {
+    env: { ...process.env, PTY_SESSION_DIR: dir, PTY_ROOT_LEGACY_SILENT: "1" },
+    encoding: "utf8", timeout: 20000,
+  });
+  return Date.now() - start;
+}
+
+describe("pty send --seq delay is applied end-to-end", () => {
+  // 4 items = 3 inter-item gaps → default ≈ 900ms of spacing, plenty above the
+  // node-startup noise floor once we subtract the straight-stream baseline.
+  const ITEMS = ["--seq", "a", "--seq", "b", "--seq", "c", "--seq", "d"];
+
+  it("default spaces items but --with-delay 0 does not (0 = straight stream)", async () => {
+    const dir = fs.mkdtempSync(path.join(testRoot, "d-"));
+    const name = `sq${Math.random().toString(36).slice(2, 6)}`;
+    await startDaemon(dir, name);
+
+    const straight = timeSend(dir, [name, "--with-delay", "0", ...ITEMS]);
+    const dflt = timeSend(dir, [name, ...ITEMS]);
+
+    // The default adds ~900ms (3 × 0.3s) over the straight stream. Generous
+    // margin (≥ 600ms) keeps it robust under load.
+    expect(dflt - straight).toBeGreaterThan(600);
+    // And the straight stream itself is quick (no 0.9s of inserted delay).
+    expect(straight).toBeLessThan(dflt - 500);
+  }, 30000);
+
+  it("--with-delay N scales the spacing", async () => {
+    const dir = fs.mkdtempSync(path.join(testRoot, "d-"));
+    const name = `sq${Math.random().toString(36).slice(2, 6)}`;
+    await startDaemon(dir, name);
+
+    const straight = timeSend(dir, [name, "--with-delay", "0", ...ITEMS]);
+    const slow = timeSend(dir, [name, "--with-delay", "0.2", ...ITEMS]);
+
+    // 3 gaps × 0.2s ≈ 600ms over the straight baseline.
+    expect(slow - straight).toBeGreaterThan(400);
+  }, 30000);
+});


### PR DESCRIPTION
Toward "pty is independently useful: a great `--help` (the reference) + a thin `SKILL.md` (the judgment)". Three bundled pieces.

## 1. `--help` — the reference
- **Every subcommand now ships focused `--help`** (usage synopsis + every flag + ≥1 concrete example) via a central `COMMAND_HELP` registry and a single interceptor. Before this, most subcommands **errored or silently ran** on `--help` (e.g. `pty list --help` listed sessions; `pty peek --help` errored).
- `renameUsage` / `printEmitHelp` now read from the same `COMMAND_HELP` source, so error-usage and `--help` can't drift.
- Top-level `usage()` already listed every subcommand; fixed the one real drift (`run --force` was missing).
- **`tests/help.test.ts`** asserts every subcommand (and alias) has working `--help`, and that **no dispatch `case` is undocumented** — a new subcommand added without help fails the test.
- `--first-position` only, so `pty send <ref> --help` still sends "--help" as text.

## 2. `--seq` default delay (Nathan's decision)
- `pty send --seq` now inserts a **0.3s gap between items by default** so a trailing `key:return` doesn't race ahead of the program parsing the typed text.
- **`--with-delay 0` = straight stream** (opt-out); `--with-delay N` honored as before.
- `resolveSeqDelayMs()` (pure, in `client.ts`) is the single decision point; the library `send()` still treats `delayMs` literally, so **programmatic callers are unchanged**.
- **`tests/seq-delay.test.ts`**: deterministic (a) default = 300ms, (b) `--with-delay 0` = 0, (c) N = N·1000; plus a delta-timed end-to-end check proving `0` = no spacing.
- `pty send --help` + top-level usage state the 0.3 default and the 0 opt-out.

### Back-compat audit (the default flips 0 → 0.3)
- **In-repo:** the only `--seq`-without-`--with-delay` callers are `tests/send-paste.test.ts` (which pair `--seq` with `--paste`); they still pass — content is unchanged, just marginally slower.
- **The ding** passes an explicit `--with-delay 0.5` → **unaffected**.
- **Eval harness (lib-harness)** is a separate repo — flag for its owner: any `--seq` call there relying on a zero-default straight stream now gets 0.3s; opt out with `--with-delay 0`.
- **`--paste` interaction:** the 0.3s default now applies *between* items inside a bracketed-paste wrapper. Bracketed paste is atomic (the receiver buffers to the close marker), so this adds latency but doesn't change semantics. Open question: should `--paste` imply `--with-delay 0`? I left it uniform per the literal decision — easy to special-case if you'd prefer.

## 3. `SKILL.md` — the judgment (thinned)
Reshaped to the routing-hook frontmatter (`description` + `when_to_use`, ~740 chars, under cap) + what / when / idiom / footguns / delegate-to-`--help`. Footguns captured: a broken global `pty` on `$PATH` silently breaks the whole message bus (`st` shells to `pty send`); `PTY_ROOT` is the isolation mechanism (`PTY_SESSION_DIR` is masked under an ambient `PTY_ROOT`); and the `--seq` timing footgun **with the why**, now mostly handled by the default.

## Verified
Full suite green (1252 passed); `npm run typecheck` clean; every subcommand `--help` exits 0 with usage + example; manual timing confirmed (default ≈600ms of gaps, `--with-delay 0` ≈ startup-only).
