### PR TITLE
fix: pty kill waits for daemon exit; shutdown doesn't resurrect removed metadata

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -15,6 +15,7 @@ import {
   isGone,
   cleanupAll,
   cleanupSocket,
+  waitForProcessExit,
   validateName,
   validateDisplayName,
   acquireLock,
@@ -2087,11 +2088,21 @@ async function cmdKill(name: string): Promise<void> {
 
   try {
     process.kill(session.pid, "SIGTERM");
-    console.log(`Session "${name}" killed.`);
   } catch {
     console.error(`Failed to kill session "${name}".`);
+    cleanupSocket(name);
+    return;
   }
+
+  // Wait for the daemon to fully exit before returning. Its shutdown re-flushes
+  // exit metadata to disk (an atomic tmp-write + rename); if we returned while
+  // that was still in flight, a caller that immediately `pty rm`s the session
+  // could race the late write and leave a stray temp file behind. Bounded — the
+  // SIGTERM shutdown path settles in ~2s; if it somehow overruns we clean up and
+  // return anyway (the daemon finishes on its own).
+  await waitForProcessExit(session.pid, 3000);
   cleanupSocket(name);
+  console.log(`Session "${name}" killed.`);
 
   if (wasPermanent && session.metadata?.tags?.ptyfile) {
     console.error(`Note: this session is managed by ${session.metadata.tags.ptyfile}`);

--- a/src/server.ts
+++ b/src/server.ts
@@ -20,6 +20,7 @@ import {
 import {
   getSocketPath,
   getPidPath,
+  getMetadataPath,
   ensureSessionDir,
   cleanup,
   cleanupAll,
@@ -879,6 +880,11 @@ export class PtyServer {
   }
 
   private saveExitMetadata(exitCode: number): void {
+    // Don't resurrect a session whose metadata was already removed. On teardown
+    // the daemon re-flushes exit metadata during its (possibly watchdog-delayed)
+    // shutdown; if a caller already `pty rm`'d the session, re-creating its
+    // `.json` here would leave a stray registry file (and its atomic tmp) behind.
+    if (!fs.existsSync(getMetadataPath(this.name))) return;
     const existing = readMetadata(this.name);
     writeMetadata(this.name, {
       command: this.options.command,

--- a/src/sessions.ts
+++ b/src/sessions.ts
@@ -1047,13 +1047,26 @@ function readPid(name: string): number | null {
   }
 }
 
-function isProcessAlive(pid: number): boolean {
+export function isProcessAlive(pid: number): boolean {
   try {
     process.kill(pid, 0);
     return true;
   } catch {
     return false;
   }
+}
+
+/** Poll until `pid` is gone (or `timeoutMs` elapses). Returns true if the
+ *  process exited within the budget, false if it was still alive at timeout.
+ *  Used by `pty kill` to wait for the daemon's shutdown (which re-flushes exit
+ *  metadata) to finish before returning, so a following `pty rm` can't race it. */
+export async function waitForProcessExit(pid: number, timeoutMs: number): Promise<boolean> {
+  const start = Date.now();
+  while (Date.now() - start < timeoutMs) {
+    if (!isProcessAlive(pid)) return true;
+    await new Promise((r) => setTimeout(r, 50));
+  }
+  return !isProcessAlive(pid);
 }
 
 function isSocketReachable(socketPath: string): Promise<boolean> {

--- a/tests/kill-wait.test.ts
+++ b/tests/kill-wait.test.ts
@@ -1,0 +1,90 @@
+import { describe, it, expect, afterAll } from "vitest";
+import * as fs from "node:fs";
+import * as os from "node:os";
+import * as path from "node:path";
+import { fileURLToPath } from "node:url";
+import { spawnSync } from "node:child_process";
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const nodeBin = process.execPath;
+const cliPath = path.join(__dirname, "..", "dist", "cli.js");
+const testRoot = fs.mkdtempSync(path.join(os.tmpdir(), "pty-killw-"));
+const bgPids: number[] = [];
+afterAll(() => {
+  for (const pid of bgPids) { try { process.kill(pid, "SIGTERM"); } catch {} }
+  fs.rmSync(testRoot, { recursive: true, force: true, maxRetries: 3, retryDelay: 100 });
+});
+
+function isAlive(pid: number): boolean {
+  try { process.kill(pid, 0); return true; } catch { return false; }
+}
+
+function runCli(dir: string, args: string[]) {
+  return spawnSync(nodeBin, [cliPath, ...args], {
+    env: { ...process.env, PTY_SESSION_DIR: dir, PTY_ROOT_LEGACY_SILENT: "1" },
+    encoding: "utf8", timeout: 15000,
+  });
+}
+
+/** Create a real detached session (the production path) and return its pid. */
+function createSession(dir: string, name: string): number {
+  const r = runCli(dir, ["run", "-d", "--id", name, "--", "cat"]);
+  expect(r.status).toBe(0);
+  const pid = Number(fs.readFileSync(path.join(dir, `${name}.pid`), "utf8").trim());
+  bgPids.push(pid);
+  return pid;
+}
+
+describe("pty kill waits for the daemon to fully exit", () => {
+  it("the daemon process is gone by the time `pty kill` returns", () => {
+    const dir = fs.mkdtempSync(path.join(testRoot, "d-"));
+    const pid = createSession(dir, "kw");
+    expect(isAlive(pid)).toBe(true);
+
+    const r = runCli(dir, ["kill", "kw"]);
+    expect(r.status).toBe(0);
+    expect(r.stdout).toContain("killed");
+    // The point of the fix: kill blocked until the daemon (and its shutdown
+    // metadata re-flush) finished, so the pid is already dead here — not racing
+    // a caller that immediately `pty rm`s the session.
+    expect(isAlive(pid)).toBe(false);
+  }, 20000);
+
+  it("a follow-up `pty rm` after kill leaves no stray files (no late-flush race)", () => {
+    const dir = fs.mkdtempSync(path.join(testRoot, "d-"));
+    createSession(dir, "kw2");
+
+    expect(runCli(dir, ["kill", "kw2"]).status).toBe(0);
+    expect(runCli(dir, ["rm", "kw2"]).status).toBe(0);
+
+    // Daemon fully exited before kill returned, so rm removed the final state
+    // and nothing (metadata or a `.tmp.*`) can reappear.
+    const leftovers = fs.readdirSync(dir).filter((f) => f.startsWith("kw2"));
+    expect(leftovers).toEqual([]);
+  }, 20000);
+
+  it("daemon shutdown does NOT resurrect metadata that was already removed", async () => {
+    // The (ii) fix for the watchdog residue: if the session's metadata was
+    // removed (e.g. `pty rm`) while the daemon is still shutting down, the
+    // daemon's late exit-metadata re-flush must not re-create the `.json`.
+    const dir = fs.mkdtempSync(path.join(testRoot, "d-"));
+    const pid = createSession(dir, "kw3");
+    const metaPath = path.join(dir, "kw3.json");
+    expect(fs.existsSync(metaPath)).toBe(true);
+
+    // Remove the metadata out from under the running daemon, then trigger its
+    // shutdown (its exit-metadata write fires during shutdown).
+    fs.unlinkSync(metaPath);
+    process.kill(pid, "SIGTERM");
+    const start = Date.now();
+    while (Date.now() - start < 6000 && isAlive(pid)) {
+      await new Promise((r) => setTimeout(r, 50));
+    }
+    await new Promise((r) => setTimeout(r, 400)); // grace for any late write
+
+    expect(isAlive(pid)).toBe(false);
+    // Must stay gone — no resurrected .json, no stray .json.tmp.*.
+    expect(fs.existsSync(metaPath)).toBe(false);
+    expect(fs.readdirSync(dir).filter((f) => f.startsWith("kw3.json"))).toEqual([]);
+  }, 20000);
+});

--- a/tests/seq-delay.test.ts
+++ b/tests/seq-delay.test.ts
@@ -72,9 +72,12 @@ function timeSend(dir: string, args: string[]): number {
 }
 
 describe("pty send --seq delay is applied end-to-end", () => {
-  // 4 items = 3 inter-item gaps → default ≈ 900ms of spacing, plenty above the
-  // node-startup noise floor once we subtract the straight-stream baseline.
-  const ITEMS = ["--seq", "a", "--seq", "b", "--seq", "c", "--seq", "d"];
+  // 9 items = 8 inter-item gaps. At the 0.3s default that's ~2.4s of real
+  // inserted delay — a large enough signal that startup / scheduling noise
+  // under a saturated parallel test run can't close the gap vs the straight
+  // stream. (The exact per-value delay is proven deterministically by the
+  // resolveSeqDelayMs unit tests above; this just proves it's wired.)
+  const ITEMS = ["a", "b", "c", "d", "e", "f", "g", "h", "i"].flatMap((v) => ["--seq", v]);
 
   it("default spaces items but --with-delay 0 does not (0 = straight stream)", async () => {
     const dir = fs.mkdtempSync(path.join(testRoot, "d-"));
@@ -84,11 +87,9 @@ describe("pty send --seq delay is applied end-to-end", () => {
     const straight = timeSend(dir, [name, "--with-delay", "0", ...ITEMS]);
     const dflt = timeSend(dir, [name, ...ITEMS]);
 
-    // The default adds ~900ms (3 × 0.3s) over the straight stream. Generous
-    // margin (≥ 600ms) keeps it robust under load.
-    expect(dflt - straight).toBeGreaterThan(600);
-    // And the straight stream itself is quick (no 0.9s of inserted delay).
-    expect(straight).toBeLessThan(dflt - 500);
+    // The default adds ~2.4s (8 × 0.3s) over the straight stream. Assert well
+    // below that (≥ 1.2s) so a saturated CI run can't false-fail.
+    expect(dflt - straight).toBeGreaterThan(1200);
   }, 30000);
 
   it("--with-delay N scales the spacing", async () => {
@@ -99,7 +100,7 @@ describe("pty send --seq delay is applied end-to-end", () => {
     const straight = timeSend(dir, [name, "--with-delay", "0", ...ITEMS]);
     const slow = timeSend(dir, [name, "--with-delay", "0.2", ...ITEMS]);
 
-    // 3 gaps × 0.2s ≈ 600ms over the straight baseline.
-    expect(slow - straight).toBeGreaterThan(400);
+    // 8 gaps × 0.2s ≈ 1.6s over the straight baseline; assert ≥ 0.9s.
+    expect(slow - straight).toBeGreaterThan(900);
   }, 30000);
 });


### PR DESCRIPTION
Low-pri teardown cleanup (from convoy-claude's diagnosis). On teardown the daemon re-flushes exit metadata during its shutdown; a caller returning before that finishes could see a stray KB registry temp file.

## Diagnosis (reproduced)
- Explicit `pty kill` re-flushes metadata **fast (~50ms)** during its SIGTERM shutdown — not 8s.
- The **~8s residue is the spawner-watchdog path**: a daemon bound to a spawner (`PTY_SPAWNER_PID`) polls every 5s; when the spawner (convoy) dies it self-terminates and flushes during that late shutdown.
- The lingering `.json.tmp.*` is a narrow race in the atomic write during a concurrent `pty rm` / teardown.

## Fix (both, per cos)
**(A) `pty kill` waits for the daemon to fully exit** (bounded 3s) before returning, so a following `pty rm` can't race the daemon's late write.
- `sessions.ts`: export `isProcessAlive` + add `waitForProcessExit()`.
- `cli.ts` `cmdKill`: SIGTERM → wait for pid exit → cleanup → done.

**(ii) `saveExitMetadata()` no-ops when the metadata was already removed** — a late shutdown/watchdog flush won't resurrect a `pty rm`'d session's `.json` (or leave its atomic tmp). Kills the watchdog-path residue at the source without touching the poll. Normal exits are unaffected (the `.json` exists at exit — verified exitCode/exitedAt still recorded).

Did **not** shorten the watchdog poll (per cos — behavior change for a cosmetic gain).

## Tests
`tests/kill-wait.test.ts`: (1) daemon gone by the time `pty kill` returns; (2) `kill`→`rm` leaves no stray files; (3) daemon shutdown does **not** resurrect metadata removed out from under it. Sessions are created the real way (`pty run -d`).

## Notes
- Also hardened `tests/seq-delay.test.ts`'s timing assertion (bigger delay signal) — it was load-flaky and my new daemon-spawning tests raised parallel load enough to expose it.
- The full vitest suite has a couple of **pre-existing** load-flaky timing tests (`agent-teams` demo, a `tui` filter test) that pass standalone and are unrelated to this change (no TUI/demo code touched). CI (`nix.yml`) runs `nix build` only, so it's unaffected.
