### PR TITLE
fix(server): surface a child's signal death (OOM SIGKILL) instead of recording exit 0

### DIFF
--- a/docs/disk-layout.md
+++ b/docs/disk-layout.md
@@ -70,7 +70,7 @@ Envelope: `{ session: string; type: string; ts: string; ...payload }`. Event typ
 | `focus_request` | — |
 | `cursor_visible` | — |
 | `session_start` | `tags?` |
-| `session_exit` | `exitCode` |
+| `session_exit` | `exitCode, signal?` — signal death (e.g. OOM SIGKILL) surfaces as `exitCode` = 128 + `signal` (SIGKILL 9 → 137), matching shell `$?`; `signal` carries the raw number |
 | `session_exec` | `previousCommand, command` |
 | `session_respawn` | — (`pty gc` respawned a `strategy=permanent` session) |
 | `session_abandoned` | `reason: "cwd-gone" \| "idle", idleDays?` — (`pty gc` reaped a live permanent session detected as abandoned) |

--- a/src/events.ts
+++ b/src/events.ts
@@ -68,7 +68,13 @@ export interface SessionStartEvent extends EventBase {
 
 export interface SessionExitEvent extends EventBase {
   type: "session_exit";
+  /** The child's exit status. A signal death (e.g. OOM SIGKILL) is surfaced as
+   *  128 + signal (SIGKILL 9 → 137), matching shell `$?` semantics, so a
+   *  consumer gating on "nonzero" catches it. */
   exitCode: number;
+  /** The raw signal number when the child was killed by a signal (absent on a
+   *  normal exit). `exitCode` already encodes it as 128 + signal. */
+  signal?: number;
 }
 
 export interface SessionExecEvent extends EventBase {
@@ -503,7 +509,9 @@ export function formatEvent(event: EventRecord): string {
       return `${prefix} started${tagStr}`;
     }
     case "session_exit":
-      return `${prefix} exited (code ${event.exitCode})`;
+      return event.signal
+        ? `${prefix} killed by signal ${event.signal} (code ${event.exitCode})`
+        : `${prefix} exited (code ${event.exitCode})`;
     case "session_exec":
       return `${prefix} exec ${event.command} (was ${event.previousCommand})`;
     case "session_respawn":

--- a/src/server.ts
+++ b/src/server.ts
@@ -497,18 +497,27 @@ export class PtyServer {
       }
     });
 
-    this.ptyProcess.onExit(({ exitCode }) => {
+    this.ptyProcess.onExit(({ exitCode, signal }) => {
       this.exited = true;
-      this.exitCode = exitCode;
-      this.broadcast(encodeExit(exitCode));
-      this.emitEvent(EventType.SESSION_EXIT, { exitCode });
+      // A signal death (e.g. an OS OOM SIGKILL) arrives from node-pty with a
+      // nonzero `signal` and often exitCode 0 — if we recorded only the raw
+      // exitCode, a killed process would look like a clean finish and any
+      // consumer gating on "nonzero exit" (convoy's crash→ding) would miss it.
+      // Surface it the way a shell does: 128 + signal (SIGKILL 9 → 137).
+      const code = signal ? 128 + signal : exitCode;
+      this.exitCode = code;
+      this.broadcast(encodeExit(code));
+      this.emitEvent(EventType.SESSION_EXIT, {
+        exitCode: code,
+        ...(signal ? { signal } : {}),
+      });
       // Save exit status immediately so the session shows as "exited"
       // in pty list during the cleanup window. lastLines may be incomplete
       // here since PTY data could still be in-flight — close() will
       // update with the final output.
-      this.saveExitMetadata(exitCode);
+      this.saveExitMetadata(code);
       this.resolveChildExited();
-      options.onExit?.(exitCode);
+      options.onExit?.(code);
     });
 
     // Create Unix socket server

--- a/tests/exit-signal.test.ts
+++ b/tests/exit-signal.test.ts
@@ -1,0 +1,88 @@
+import { describe, it, expect, afterAll } from "vitest";
+import * as fs from "node:fs";
+import * as os from "node:os";
+import * as path from "node:path";
+import { fileURLToPath } from "node:url";
+import { spawnSync, execFileSync } from "node:child_process";
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const nodeBin = process.execPath;
+const cliPath = path.join(__dirname, "..", "dist", "cli.js");
+const testRoot = fs.mkdtempSync(path.join(os.tmpdir(), "pty-sig-"));
+const bgPids: number[] = [];
+afterAll(() => {
+  for (const pid of bgPids) { try { process.kill(pid, "SIGKILL"); } catch {} }
+  fs.rmSync(testRoot, { recursive: true, force: true, maxRetries: 3, retryDelay: 100 });
+});
+
+function runCli(dir: string, args: string[]) {
+  return spawnSync(nodeBin, [cliPath, ...args], {
+    env: { ...process.env, PTY_SESSION_DIR: dir, PTY_ROOT_LEGACY_SILENT: "1" },
+    encoding: "utf8", timeout: 15000,
+  });
+}
+
+function createSession(dir: string, name: string, cmd: string[]): number {
+  expect(runCli(dir, ["run", "-d", "--id", name, "--", ...cmd]).status).toBe(0);
+  const pid = Number(fs.readFileSync(path.join(dir, `${name}.pid`), "utf8").trim());
+  bgPids.push(pid);
+  return pid;
+}
+
+function readMeta(dir: string, name: string): any {
+  return JSON.parse(fs.readFileSync(path.join(dir, `${name}.json`), "utf8"));
+}
+
+async function waitForExit(dir: string, name: string): Promise<any> {
+  const start = Date.now();
+  while (Date.now() - start < 8000) {
+    try {
+      const m = readMeta(dir, name);
+      if (m.exitedAt) return m;
+    } catch {}
+    await new Promise((r) => setTimeout(r, 50));
+  }
+  throw new Error(`session "${name}" never recorded an exit`);
+}
+
+describe("pty surfaces a signal death (OOM SIGKILL) instead of losing it", () => {
+  it("a SIGKILL'd child is recorded as 128+signal (137), not exit 0", async () => {
+    const dir = fs.mkdtempSync(path.join(testRoot, "d-"));
+    const daemonPid = createSession(dir, "sk", ["sh", "-c", "exec sleep 300"]);
+
+    // The session's leaf is the daemon's direct child (exec replaces the sh).
+    const leaf = Number(
+      execFileSync("pgrep", ["-P", String(daemonPid)], { encoding: "utf8" }).trim().split("\n")[0],
+    );
+    expect(Number.isInteger(leaf)).toBe(true);
+
+    process.kill(leaf, "SIGKILL"); // simulate an OS OOM kill
+
+    const meta = await waitForExit(dir, "sk");
+    // Was exit 0 (clean finish) before the fix — a real crash that convoy's
+    // nonzero gate would have missed. Now surfaced as 128 + SIGKILL(9) = 137.
+    expect(meta.exitCode).toBe(137);
+
+    // The raw signal is also surfaced on the session_exit event.
+    const events = fs.readFileSync(path.join(dir, "sk.events.jsonl"), "utf8")
+      .trim().split("\n").map((l) => JSON.parse(l));
+    const exit = events.find((e) => e.type === "session_exit");
+    expect(exit.exitCode).toBe(137);
+    expect(exit.signal).toBe(9);
+  }, 20000);
+
+  it("a clean exit is unchanged (raw code, no signal)", async () => {
+    const dir = fs.mkdtempSync(path.join(testRoot, "d-"));
+    createSession(dir, "ce", ["sh", "-c", "exit 5"]);
+
+    const meta = await waitForExit(dir, "ce");
+    expect(meta.exitCode).toBe(5);
+    expect(meta.signal).toBeUndefined();
+
+    const events = fs.readFileSync(path.join(dir, "ce.events.jsonl"), "utf8")
+      .trim().split("\n").map((l) => JSON.parse(l));
+    const exit = events.find((e) => e.type === "session_exit");
+    expect(exit.exitCode).toBe(5);
+    expect(exit.signal).toBeUndefined();
+  }, 20000);
+});


### PR DESCRIPTION
## The gap (from the crash→ding work)

When a session's child is killed by a signal (e.g. an OS **OOM SIGKILL**), pty recorded the exit as **exitCode 0** — a clean finish. A consumer gating on "nonzero || null || vanished" (convoy's crash→ding) then treated a real OOM-killed worker as a normal exit and stayed silent → the supervisor got **no ding**.

## Root cause (a)

`src/server.ts` — the daemon's child-exit handler destructured only `exitCode`:

```ts
this.ptyProcess.onExit(({ exitCode }) => { … })   // dropped `signal`
```

node-pty actually reports **`{ exitCode: number, signal?: number }`** (`node-pty` typings `onExit`). On a signal death it delivers `signal` (9 for SIGKILL) with `exitCode` 0 — and pty threw the signal away.

## Bug or platform limit? (b)

**A bug — the signal was available and dropped, not a platform limitation.** Reproduced: `pty run -d -- sh -c 'exec sleep 300'`, then `kill -9` the leaf → recorded `exitCode: 0` (event too).

## Fix (c)

Capture the signal and surface it the way a shell does — **`exitCode = 128 + signal`** (SIGKILL 9 → **137**) — so convoy's existing nonzero gate catches OOM with **no convoy change**. Also carry the raw **`signal`** on the `session_exit` event (and render "killed by signal N").

- `server.ts` onExit: effective code `signal ? 128 + signal : exitCode`, used for the broadcast, event, metadata, and `onExit` callback.
- `events.ts`: `SessionExitEvent` gains optional `signal`; `formatEvent` shows it.
- `docs/disk-layout.md`: documents the `session_exit` `signal` field + encoding.

Kept it in the `exitCode` (metadata) so `pty list --json`'s `exitCode` is 137 (nonzero) — no metadata format change, no consumer changes needed. The signal is derivable (`exitCode - 128`) and explicit on the event.

## Verified

- SIGKILL'd child → metadata `exitCode: 137`, event `{exitCode:137, signal:9}`, renders "killed by signal 9 (code 137)".
- Clean `exit 5` → `exitCode: 5`, no signal (unchanged).
- `tests/exit-signal.test.ts` covers both. Full suite green (1215); typecheck clean; disk-layout-docs smoke test passes.
