### PR TITLE
fix(daemon): hard-exit backstop when a graceful shutdown wedges

### DIFF
--- a/src/server.ts
+++ b/src/server.ts
@@ -941,6 +941,15 @@ export class PtyServer {
       });
     });
   }
+
+  /** Hard-kill the child with SIGKILL, bypassing the graceful SIGHUP that
+   *  close() sends. Used by the shutdown backstop: when a graceful close()
+   *  has wedged (e.g. a frozen child that ignores SIGHUP), the daemon is about
+   *  to force-exit and must not leave the child orphaned to init still alive.
+   *  Best-effort — a SIGKILL is unblockable, but the child may already be gone. */
+  forceKillChild(): void {
+    try { this.ptyProcess.kill("SIGKILL"); } catch {}
+  }
 }
 
 /** How often the spawner-PID watchdog checks for liveness. 5s is fast enough
@@ -998,11 +1007,45 @@ if (process.argv[1]?.endsWith("/server.js")) {
 
   const isEphemeral = config.ephemeral === true;
 
+  // Hard deadline for a graceful shutdown before the daemon force-exits. The
+  // graceful path (server.close()) is itself only internally bounded on the
+  // child-exit wait (~2s); the outer promise can still hang indefinitely if
+  // socketServer.close()'s callback never fires (a lingering/untracked socket)
+  // or eventWriter.flush() stalls. That is exactly how a restart wedged the
+  // daemon alive+orphaned (ppid=1), needing kill -9. This backstop guarantees
+  // the daemon exits — and reaps its child — regardless. Env-overridable so
+  // tests can force the backstop path deterministically.
+  const SHUTDOWN_DEADLINE_MS = (() => {
+    const raw = Number(process.env.PTY_SHUTDOWN_DEADLINE_MS);
+    return Number.isFinite(raw) && raw > 0 ? raw : 5000;
+  })();
+
+  // Idempotent: SIGTERM, SIGINT, the child's onExit, and the spawner watchdog
+  // can all trigger shutdown, sometimes overlapping. Only the first arms the
+  // deadline and drives close(); later callers get the same in-flight promise.
+  let shutdownPromise: Promise<never> | null = null;
   function cleanShutdown(code: number): Promise<never> {
-    return server.close().then(() => {
+    if (shutdownPromise) return shutdownPromise;
+    const deadline = setTimeout(() => {
+      console.error(
+        `pty daemon "${config.name}": graceful shutdown exceeded ` +
+        `${SHUTDOWN_DEADLINE_MS}ms — forcing exit (child reaped)`,
+      );
+      // Don't leave a frozen child orphaned, and don't leave a stale pid/sock
+      // pointing at a daemon that's about to vanish.
+      server.forceKillChild();
+      try {
+        if (isEphemeral) cleanupAll(config.name);
+        else cleanup(config.name);
+      } catch {}
+      process.exit(code);
+    }, SHUTDOWN_DEADLINE_MS);
+    shutdownPromise = server.close().then(() => {
+      clearTimeout(deadline);
       if (isEphemeral) cleanupAll(config.name);
       process.exit(code);
     });
+    return shutdownPromise;
   }
 
   const server = new PtyServer({

--- a/tests/shutdown-backstop.test.ts
+++ b/tests/shutdown-backstop.test.ts
@@ -1,0 +1,123 @@
+import { describe, it, expect, afterAll } from "vitest";
+import * as fs from "node:fs";
+import * as os from "node:os";
+import * as path from "node:path";
+import { fileURLToPath } from "node:url";
+import { spawn } from "node:child_process";
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const nodeBin = process.execPath;
+const serverModule = path.join(__dirname, "..", "dist", "server.js");
+
+const testRoot = fs.mkdtempSync(path.join(os.tmpdir(), "pty-backstop-"));
+const spawnedPids: number[] = [];
+afterAll(() => {
+  for (const pid of spawnedPids) { try { process.kill(pid, "SIGKILL"); } catch {} }
+  fs.rmSync(testRoot, { recursive: true, force: true, maxRetries: 3, retryDelay: 100 });
+});
+
+function isAlive(pid: number): boolean {
+  try {
+    process.kill(pid, 0);
+    return true;
+  } catch (err) {
+    return (err as NodeJS.ErrnoException).code === "EPERM";
+  }
+}
+
+async function waitUntilDead(pid: number, timeoutMs: number): Promise<boolean> {
+  const start = Date.now();
+  while (Date.now() - start < timeoutMs) {
+    if (!isAlive(pid)) return true;
+    await new Promise((r) => setTimeout(r, 50));
+  }
+  return false;
+}
+
+function waitForFile(p: string, timeoutMs: number): Promise<void> {
+  const start = Date.now();
+  return new Promise((resolve, reject) => {
+    const tick = () => {
+      try { fs.statSync(p); resolve(); return; } catch {}
+      if (Date.now() - start > timeoutMs) { reject(new Error(`Timeout waiting for ${p}`)); return; }
+      setTimeout(tick, 50);
+    };
+    tick();
+  });
+}
+
+/** Spawn a daemon directly (the real server.js entry point), running `command`
+ *  with `args`, and with the given extra env (e.g. PTY_SHUTDOWN_DEADLINE_MS).
+ *  Returns the daemon PID once its socket exists. */
+async function startDaemon(
+  sessionDir: string,
+  name: string,
+  command: string,
+  args: string[],
+  extraEnv: Record<string, string> = {},
+): Promise<number> {
+  const config = JSON.stringify({
+    name, command, args, displayCommand: `${command} ${args.join(" ")}`,
+    cwd: os.tmpdir(), rows: 24, cols: 80,
+  });
+  const child = spawn(nodeBin, [serverModule], {
+    detached: true,
+    stdio: ["ignore", "ignore", "ignore"],
+    env: {
+      ...(process.env as Record<string, string>),
+      PTY_SERVER_CONFIG: config,
+      PTY_SESSION_DIR: sessionDir,
+      ...extraEnv,
+    },
+  });
+  child.unref();
+  spawnedPids.push(child.pid!);
+  await waitForFile(path.join(sessionDir, `${name}.sock`), 5000);
+  return child.pid!;
+}
+
+describe("daemon shutdown-hang backstop", () => {
+  it("force-exits and reaps a frozen child when graceful shutdown exceeds the deadline", async () => {
+    const sessionDir = fs.mkdtempSync(path.join(testRoot, "d-"));
+    const name = `bs-${Math.random().toString(36).slice(2, 6)}`;
+    const childPidFile = path.join(sessionDir, "child.pid");
+
+    // A child that traps SIGHUP: close()'s graceful `ptyProcess.kill()` (SIGHUP)
+    // is ignored, so childExited never resolves and the graceful shutdown drags.
+    // Only the backstop's SIGKILL can reap it — which is exactly what we assert.
+    const script = `echo $$ > "${childPidFile}"; trap "" HUP; while true; do sleep 1; done`;
+    const daemonPid = await startDaemon(
+      sessionDir, name, "sh", ["-c", script],
+      { PTY_SHUTDOWN_DEADLINE_MS: "300" },
+    );
+
+    await waitForFile(childPidFile, 5000);
+    const childPid = Number(fs.readFileSync(childPidFile, "utf8").trim());
+    spawnedPids.push(childPid);
+    expect(isAlive(childPid)).toBe(true);
+
+    // Initiate shutdown. The graceful path can't complete (frozen child), so the
+    // 300ms backstop must fire: force-exit the daemon AND SIGKILL the child.
+    process.kill(daemonPid, "SIGTERM");
+
+    // Daemon self-exits despite the wedged close() (no kill -9 needed).
+    expect(await waitUntilDead(daemonPid, 4000)).toBe(true);
+    // The frozen child is reaped, not left orphaned to init. This is the
+    // timing-independent proof: without the backstop the child only ever
+    // receives a (trapped) SIGHUP and would survive.
+    expect(await waitUntilDead(childPid, 4000)).toBe(true);
+  }, 15000);
+
+  it("does not disturb a normal, prompt shutdown", async () => {
+    const sessionDir = fs.mkdtempSync(path.join(testRoot, "d-"));
+    const name = `bs-ok-${Math.random().toString(36).slice(2, 6)}`;
+
+    // Plain child that exits on the graceful SIGHUP — the default (5s) deadline
+    // never comes near firing; graceful close() completes and exits promptly.
+    const daemonPid = await startDaemon(sessionDir, name, "sleep", ["3600"]);
+    expect(isAlive(daemonPid)).toBe(true);
+
+    process.kill(daemonPid, "SIGTERM");
+    expect(await waitUntilDead(daemonPid, 3000)).toBe(true);
+  }, 10000);
+});


### PR DESCRIPTION
Follow-up **#2** from the cos-restart incident (guardrail #73 was #1). Guarantees a daemon can't get wedged **alive + orphaned** needing `kill -9`.

## The wedge
When cos's `claude --resume` froze on its exit screen, the daemon was left **alive, orphaned (ppid=1)** — reclaiming it needed `kill -9` on both the daemon and the frozen claude.

Root cause in the shutdown path (`server.ts` entry point):
```
cleanShutdown(code) -> server.close() -> process.exit(code)   // no overall deadline
```
`close()`'s child-exit wait is internally bounded (~2s), but the **outer** promise can hang **indefinitely**:
- `socketServer.close(cb)`'s callback never fires for a lingering/untracked socket, or
- `eventWriter.flush()` stalls on a frozen child.

If the promise never resolves, `process.exit()` is never reached → the daemon lingers forever.

## Fix
`cleanShutdown` now arms a **hard deadline** (default 5s, `PTY_SHUTDOWN_DEADLINE_MS`-overridable). If graceful `close()` hasn't completed by the deadline, the daemon:
1. **force-exits** regardless (`process.exit(code)`), and
2. **SIGKILLs its child** (`PtyServer.forceKillChild`) so a frozen child isn't left orphaned to init still alive, and
3. best-effort clears the pid/sock so nothing points at the vanished daemon.

`cleanShutdown` is also now **idempotent** — SIGTERM / SIGINT / the child's `onExit` / the spawner watchdog can overlap; only the first arms the deadline and drives `close()`, the rest share the in-flight promise. (A `close()` *rejection* is covered too — the deadline is the net.)

The normal fast path is untouched: on a clean shutdown `close()` resolves in well under the deadline, the timer is cleared, and the daemon exits promptly as before.

## Tests — `tests/shutdown-backstop.test.ts`
- **Backstop fires + reaps:** a child that `trap "" HUP` wedges the graceful path (SIGHUP is ignored, so `childExited` drags). The backstop force-exits the daemon **and** the child ends up dead. This is a **timing-independent** proof: the graceful path only ever sends the child SIGHUP, so a SIGHUP-trapping child would survive as an orphan — **only** the backstop's SIGKILL can reap it. (deadline set to 300ms via env to force the path deterministically.)
- **Normal shutdown unaffected:** a plain `sleep` session SIGTERM'd exits promptly, nowhere near the deadline.

Full suite: 1262 passed; the one red (`scrollback-fidelity`) is a **pre-existing load flake unrelated to this change** — it passes 8/8 in isolation (confirmed twice); it starves under 96-file concurrent load. Flagging separately, not fixing in this PR (unrelated area). All shutdown/lifecycle-adjacent tests (spawner-watchdog, kill-wait, exit-event-race, exit-signal, rm-kill-ephemeral, up-down, events-emit — 58 tests) pass. Build/typecheck clean.

## Queue
Next (item #3, per your call): scrub/explicitly-set bus-identity env (`ST_AGENT`/`ST_ROOT`) on restart/spawn — the deeper root cause (restart re-execs under the operator's shell env → wrong bus identity). Separate PR.
