### PR TITLE
docs: move the Nix install block from README into nix.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,12 +12,7 @@ Uses [@xterm/headless](https://github.com/xtermjs/xterm.js/tree/master/headless)
 npm install -g @myobie/pty
 ```
 
-Or with Nix:
-
-```sh
-nix profile install github:compoundingtech/pty   # install the CLI
-nix develop github:compoundingtech/pty           # dev shell with node, npm, native deps
-```
+Or install with Nix — see [nix.md](nix.md).
 
 Requires Node.js. Works on macOS and Linux.
 

--- a/nix.md
+++ b/nix.md
@@ -1,0 +1,45 @@
+# pty with Nix
+
+pty ships a [flake](flake.nix) with a package and a development shell. Both need
+[Nix](https://nixos.org/download) with flakes enabled. Works on macOS and Linux.
+
+## Install the CLI
+
+Install `pty` into your Nix profile:
+
+```sh
+nix profile install github:compoundingtech/pty
+```
+
+This builds the CLI from the flake's default package and puts `pty` on your
+`PATH`. Upgrade later with `nix profile upgrade`, remove with
+`nix profile remove`.
+
+To run it once without installing:
+
+```sh
+nix run github:compoundingtech/pty
+```
+
+## Development shell
+
+For hacking on pty itself, drop into the flake's dev shell — it provides the
+toolchain needed to build the `node-pty` native addon (Node.js, Python, and
+pkg-config):
+
+```sh
+nix develop github:compoundingtech/pty
+```
+
+Or, from a clone of this repo:
+
+```sh
+git clone https://github.com/compoundingtech/pty
+cd pty
+nix develop          # enters the dev shell with node, python3, pkg-config
+npm install
+npm run build
+```
+
+The flake's `flake.nix` is the source of truth for both the package and the dev
+shell — this document only describes how to use them.


### PR DESCRIPTION
Doc-only, reversible. Per Nathan's ask (via cos) to move Nix docs out of the READMEs into a dedicated `nix.md` across the ecosystem — pty is the only core repo with Nix doc content, so this is pty-only.

## What changed
- **README.md**: removed the `Or with Nix:` block (the `nix profile install` + `nix develop` commands); left a one-line pointer in its place under Install:
  > Or install with Nix — see [nix.md](nix.md).
- **nix.md** (new, repo root): the clean home for Nix usage —
  - **Install the CLI**: `nix profile install` (+ upgrade/remove), and `nix run` for a one-off.
  - **Development shell**: `nix develop` (+ the clone → `nix develop` → `npm install` → `npm run build` workflow), noting it provides the `node-pty` native-build toolchain.
  - Notes that `flake.nix` is the source of truth; this doc only describes how to use it.
- **flake.nix**: untouched (only the DOC content moved).

## Accuracy
Every command is verified against `flake.nix`: `packages.default` sets `meta.mainProgram = "pty"` (so `nix run` resolves), and the dev shell provides `nodejs_22` / `python3` / `pkg-config`.

## Acceptance (all met)
- README has no Nix command block — just the one-line pointer. ✓
- nix.md holds the install + dev-shell instructions. ✓
- flake.nix unchanged. ✓
- The README pointer link resolves (`nix.md` is at the repo root). ✓
